### PR TITLE
isort, black, flake8, and remove circular dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,17 @@
+name: odg
+channels:
+  - conda-forge
+dependencies:
+  - joblib
+  - shapely
+  - intake
+  - pandas
+  - xarray
+  - requests
+  - flake8
+  - isort
+  - erddapy
+  - pytest
+  - ipython
+  - aiohttp
+  - intake-xarray

--- a/ocean_data_gateway/__init__.py
+++ b/ocean_data_gateway/__init__.py
@@ -1,34 +1,37 @@
+import logging
+from pathlib import Path
+
 try:
     from ._version import __version__
 except ImportError:
     __version__ = "unknown"
 
 
-## make necessary directories ##
+base_path = Path.home() / ".ocean_data_gateway"
+base_path.mkdir(exist_ok=True)
 
-# make base dir in user home directory
-import pathlib
-path_base = pathlib.Path.home().joinpath('.ocean_data_gateway')
-path_base.mkdir(parents=True, exist_ok=True)
+logs_path = base_path / "logs"
+logs_path.mkdir(exist_ok=True)
 
-# make subdirectories too
-path_catalogs = path_base.joinpath('catalogs')
-path_catalogs.mkdir(parents=True, exist_ok=True)
-path_logs = path_base.joinpath('logs')
-path_logs.mkdir(parents=True, exist_ok=True)
-path_variables = path_base.joinpath('variables')
-path_variables.mkdir(parents=True, exist_ok=True)
+catalogs_path = base_path / "catalogs"
+catalogs_path.mkdir(exist_ok=True)
 
+variables_path = base_path / "variables"
+variables_path.mkdir(exist_ok=True)
 
-# import search.search
-from .readers import erddap, axds, local
-from .gateway import Gateway
-# import ocean_data_gateway.readers.erddap
-# import readers.axds
-# import readers.local
-#
-# from .gateway import (gateway)
-# import Data
-# from .ErddapReader import (ErddapReader, region)
-# from .axdsReader import (axdsReader)
-# from .localReader import (localReader)
+logger = logging.getLogger(__name__)
+formatter = logging.Formatter("%(asctime)s %(message)s", "%a %b %d %H:%M:%S %Z %Y")
+
+stream_handler = logging.StreamHandler()
+stream_handler.setLevel(logging.WARNING)
+stream_handler.setFormatter(formatter)
+
+root_log_path = logs_path / f"{__name__}.log"
+file_handler = logging.FileHandler(root_log_path)
+file_handler.setLevel(logging.WARNING)
+file_handler.setFormatter(formatter)
+
+logger.addHandler(stream_handler)
+logger.addHandler(file_handler)
+# warnings are captured and only output to file_handler
+logging.captureWarnings(True)

--- a/ocean_data_gateway/gateway.py
+++ b/ocean_data_gateway/gateway.py
@@ -1,9 +1,9 @@
 import ocean_data_gateway as odg
+
 # from search.ErddapReader import ErddapReader
 # from search.axdsReader import axdsReader
 # from search.localReader import localReader
 
-import pandas as pd
 
 # # data functions by data_type
 # DATASOURCES_GRID = [hfradar, seaice_extent, seaice_con]
@@ -13,60 +13,57 @@ import pandas as pd
 # GO THROUGH ALL KNOWN SOURCES?
 # SOURCES = [ErddapReader(known_server='ioos'),
 #            ErddapReader(known_server='coastwatch'),
-_SOURCES = [odg.erddap,
-           odg.axds,
-           odg.local]
+_SOURCES = [odg.erddap, odg.axds, odg.local]
 
-OPTIONS = {'erddap': {'known_server': ['ioos', 'coastwatch']},
-           'axds': {'axds_type': ['platform2', 'layer_group']}}
+OPTIONS = {
+    "erddap": {"known_server": ["ioos", "coastwatch"]},
+    "axds": {"axds_type": ["platform2", "layer_group"]},
+}
 
 # MAYBE SHOULD BE ABLE TO INITIALIZE THE CLASS WITH ONLY METADATA OR DATASET NAMES?
 # to skip looking for the datasets
 
+
 class Gateway(object):
-
-    def __init__(self, **kwargs):# kw=None, variables=None):
-
+    def __init__(self, **kwargs):
         # set up a dictionary for general input kwargs
-        exclude_keys = ['erddap', 'axds', 'local']
-        kwargs_all = {k: kwargs[k] for k in set(list(kwargs.keys()))
-                                          - set(exclude_keys)}
+        exclude_keys = ["erddap", "axds", "local"]
+        kwargs_all = {
+            k: kwargs[k] for k in set(list(kwargs.keys())) - set(exclude_keys)
+        }
 
         self.kwargs_all = kwargs_all
 
         # default approach is region
-        if not 'approach' in self.kwargs_all:
-            self.kwargs_all['approach'] = 'region'
+        if "approach" not in self.kwargs_all:
+            self.kwargs_all["approach"] = "region"
 
         assertion = '`approach` has to be "region" or "stations"'
-        assert self.kwargs_all['approach'] in ['region','stations'], assertion
+        assert self.kwargs_all["approach"] in ["region", "stations"], assertion
 
-        if not 'kw' in self.kwargs_all:
+        if "kw" not in self.kwargs_all:
             kw = {
                 "min_lon": -124.0,
                 "max_lon": -122.0,
                 "min_lat": 38.0,
                 "max_lat": 40.0,
-                "min_time": '2021-4-1',
-                "max_time": '2021-4-2',
+                "min_time": "2021-4-1",
+                "max_time": "2021-4-2",
             }
-            self.kwargs_all['kw'] = kw
-
+            self.kwargs_all["kw"] = kw
 
         self.kwargs = kwargs
-
         self.sources
 
     @property
     def sources(self):
-        '''Set up data sources.
-        '''
+        """Set up data sources."""
 
-        if not hasattr(self, '_sources'):
+        if not hasattr(self, "_sources"):
 
             # allow user to override what readers to use
-            if 'readers' in self.kwargs_all.keys():
-                SOURCES = self.kwargs_all['readers']
+            if "readers" in self.kwargs_all.keys():
+                SOURCES = self.kwargs_all["readers"]
                 if not isinstance(SOURCES, list):
                     SOURCES = [SOURCES]
             else:
@@ -75,18 +72,20 @@ class Gateway(object):
             # loop over data sources to set them up
             sources = []
             for source in SOURCES:
-#                 print(source.reader)
+                #                 print(source.reader)
 
                 # in case of important options for readers
                 # but the built in options are ignored for a reader
                 # if one is input in kwargs[source.reader]
-                if (source.reader in OPTIONS.keys()):
+                if source.reader in OPTIONS.keys():
                     reader_options = OPTIONS[source.reader]
                     reader_key = list(reader_options.keys())[0]
                     # if the user input their own option for this, use it instead
                     # this makes it loop once
-                    if (source.reader in self.kwargs.keys()) and (reader_key in self.kwargs[source.reader]):
-#                         reader_values = [None]
+                    if (source.reader in self.kwargs.keys()) and (
+                        reader_key in self.kwargs[source.reader]
+                    ):
+                        #                         reader_values = [None]
                         reader_values = self.kwargs[source.reader][reader_key]
                     else:
                         reader_values = list(reader_options.values())[0]
@@ -100,61 +99,68 @@ class Gateway(object):
 
                 # catch if the user is putting in a set of variables to match
                 # the set of reader options
-                if (source.reader in self.kwargs) and ('variables' in self.kwargs[source.reader]):
-                    variables_values = self.kwargs[source.reader]['variables']
+                if (source.reader in self.kwargs) and (
+                    "variables" in self.kwargs[source.reader]
+                ):
+                    variables_values = self.kwargs[source.reader]["variables"]
                     if not isinstance(variables_values, list):
                         variables_values = [variables_values]
-#                     if len(reader_values) == variables_values:
-#                         variables_values
+                #                     if len(reader_values) == variables_values:
+                #                         variables_values
                 else:
-                    variables_values = [None]*len(reader_values)
+                    variables_values = [None] * len(reader_values)
 
                 # catch if the user is putting in a set of dataset_ids to match
                 # the set of reader options
-                if (source.reader in self.kwargs) and ('dataset_ids' in self.kwargs[source.reader]):
-                    dataset_ids_values = self.kwargs[source.reader]['dataset_ids']
+                if (source.reader in self.kwargs) and (
+                    "dataset_ids" in self.kwargs[source.reader]
+                ):
+                    dataset_ids_values = self.kwargs[source.reader]["dataset_ids"]
                     if not isinstance(dataset_ids_values, list):
                         dataset_ids_values = [dataset_ids_values]
-#                     if len(reader_values) == variables_values:
-#                         variables_values
+                #                     if len(reader_values) == variables_values:
+                #                         variables_values
                 else:
-                    dataset_ids_values = [None]*len(reader_values)
+                    dataset_ids_values = [None] * len(reader_values)
 
-                for option, variables, dataset_ids in zip(reader_values,variables_values,dataset_ids_values):
+                for option, variables, dataset_ids in zip(
+                    reader_values, variables_values, dataset_ids_values
+                ):
                     # setup reader with kwargs for that reader
                     # prioritize input kwargs over default args
                     # NEED TO INCLUDE kwargs that go to all the readers
                     args = {}
-                    args_in = {**args,
-                               **self.kwargs_all,
-#                                reader_key: option,
-#                                **self.kwargs[source.reader],
-                               }
+                    args_in = {
+                        **args,
+                        **self.kwargs_all,
+                        #                                reader_key: option,
+                        #                                **self.kwargs[source.reader],
+                    }
 
                     if source.reader in self.kwargs.keys():
-                        args_in = {**args_in,
-                                   **self.kwargs[source.reader],
-                                  }
+                        args_in = {
+                            **args_in,
+                            **self.kwargs[source.reader],
+                        }
 
-                    args_in = {**args_in,
-                              reader_key: option}
+                    args_in = {**args_in, reader_key: option}
 
                     # deal with variables separately
-                    args_in = {**args_in,
-                               'variables': variables,
-                              }
+                    args_in = {
+                        **args_in,
+                        "variables": variables,
+                    }
 
                     # deal with dataset_ids separately
-                    args_in = {**args_in,
-                               'dataset_ids': dataset_ids,
-                              }
+                    args_in = {
+                        **args_in,
+                        "dataset_ids": dataset_ids,
+                    }
 
-
-                    if self.kwargs_all['approach'] == 'region':
+                    if self.kwargs_all["approach"] == "region":
                         reader = source.region(args_in)
-                    elif self.kwargs_all['approach'] == 'stations':
+                    elif self.kwargs_all["approach"] == "stations":
                         reader = source.stations(args_in)
-
 
                     sources.append(reader)
 
@@ -162,11 +168,10 @@ class Gateway(object):
 
         return self._sources
 
-
     @property
     def dataset_ids(self):
 
-        if not hasattr(self, '_dataset_ids'):
+        if not hasattr(self, "_dataset_ids"):
 
             dataset_ids = []
             for source in self.sources:
@@ -177,10 +182,9 @@ class Gateway(object):
 
         return self._dataset_ids
 
-
     @property
     def meta(self):
-        '''Find and return metadata for datasets.
+        """Find and return metadata for datasets.
 
         Do this by querying each data source function for metadata
         then use the metadata for quick returns.
@@ -197,9 +201,9 @@ class Gateway(object):
 
         EXPOSE DATASET_IDS?
 
-        '''
+        """
 
-        if not hasattr(self, '_meta'):
+        if not hasattr(self, "_meta"):
 
             # loop over data sources to read in metadata
             meta = []
@@ -211,12 +215,11 @@ class Gateway(object):
 
         return self._meta
 
-
     @property
     def data(self):
-        '''Return the data, given metadata.'''
+        """Return the data, given metadata."""
 
-        if not hasattr(self, '_data'):
+        if not hasattr(self, "_data"):
 
             # loop over data sources to read in data
             data = []

--- a/ocean_data_gateway/readers/axds.py
+++ b/ocean_data_gateway/readers/axds.py
@@ -1,135 +1,116 @@
-from joblib import Parallel, delayed
-import multiprocessing
-import pandas as pd
-import xarray as xr
-import logging
-import os
-import requests
-import intake
-import shapely.wkt
-import re
-import numpy as np
 import hashlib
-import pathlib
+import logging
+import multiprocessing
+import os
+import re
+
+import intake
+import numpy as np
+import pandas as pd
+import requests
+import shapely.wkt
+from joblib import Parallel, delayed
+
 import ocean_data_gateway as odg
 
 
-# Capture warnings in log
-logging.captureWarnings(True)
-
-# formatting for logfile
-formatter = logging.Formatter('%(asctime)s %(message)s','%a %b %d %H:%M:%S %Z %Y')
-log_name = 'reader_axds'
-loglevel=logging.WARNING
-path_logs_reader = odg.path_logs.joinpath(f'{log_name}.log')
-
-# set up logger file
-handler = logging.FileHandler(path_logs_reader)
-handler.setFormatter(formatter)
-logger_axds = logging.getLogger(log_name)
-logger_axds.setLevel(loglevel)
-logger_axds.addHandler(handler)
+logger = logging.getLogger(__name__)
 
 # this can be queried with
 # search.AxdsReader.reader
-reader = 'axds'
-
+reader = "axds"
 
 
 class AxdsReader:
-
-
-    def __init__(self, parallel=True, catalog_name=None, axds_type='platform2'):
-
+    def __init__(self, parallel=True, catalog_name=None, axds_type="platform2"):
 
         self.parallel = parallel
 
         # search Axiom database, version 2
-        self.url_search_base = 'https://search.axds.co/v2/search?portalId=-1&page=1&pageSize=10000&verbose=true'
-        self.url_docs_base = 'https://search.axds.co/v2/docs?verbose=true'
+        self.url_search_base = "https://search.axds.co/v2/search?portalId=-1&page=1&pageSize=10000&verbose=true"
+        self.url_docs_base = "https://search.axds.co/v2/docs?verbose=true"
 
         # this is the json being returned from the request
-        self.search_headers = {'Accept': 'application/json'}
-
+        self.search_headers = {"Accept": "application/json"}
 
         self.approach = None
 
         if catalog_name is None:
-            name = f'{pd.Timestamp.now().isoformat()}'
+            name = f"{pd.Timestamp.now().isoformat()}"
             hash_name = hashlib.sha256(name.encode()).hexdigest()[:7]
-            path_catalog = odg.path_catalogs.joinpath(f'catalog_{hash_name}.yml')
-            self.catalog_name = path_catalog#.name
+            self.catalog_name = odg.catalogs_path.joinpath(f"catalog_{hash_name}.yml")
         else:
             self.catalog_name = catalog_name
             # if catalog_name already exists, read it in to save time
             self.catalog
 
-
         # can be 'platform2' or 'layer_group'
-        assert axds_type in ['platform2','layer_group'], 'variable `axds_type` must be "platform2" or "layer_group"'
+        assert axds_type in [
+            "platform2",
+            "layer_group",
+        ], 'variable `axds_type` must be "platform2" or "layer_group"'
         self.axds_type = axds_type
 
-        self.url_axds_type = f'{self.url_search_base}&type={self.axds_type}'
-
-
-#         # run checks for KW
-#         self.kw = kw
-
-
-        # name
-        self.name = f'axds_{axds_type}'
-
-        self.reader = 'AxdsReader'
-
-
+        self.url_axds_type = f"{self.url_search_base}&type={self.axds_type}"
+        self.name = f"axds_{axds_type}"
+        self.reader = "AxdsReader"
 
     def url_query(self, query):
-        return f'&query={query}'
+        return f"&query={query}"
 
     def url_variable(self, variable):
-        '''by parameter group'''
-        return f'&tag=Parameter+Group:{variable}'
-
+        """by parameter group"""
+        return f"&tag=Parameter+Group:{variable}"
 
     def url_region(self):
         # add lonlat filtering
-        url_add_box = f'&geom={{"type":"Polygon","coordinates":[[[{self.kw["min_lon"]},{self.kw["min_lat"]}],' \
-                                + f'[{self.kw["max_lon"]},{self.kw["min_lat"]}],' \
-                                + f'[{self.kw["max_lon"]},{self.kw["max_lat"]}],' \
-                                + f'[{self.kw["min_lon"]},{self.kw["max_lat"]}],' \
-                                + f'[{self.kw["min_lon"]},{self.kw["min_lat"]}]]]}}'
-        return f'{url_add_box}'
-
+        url_add_box = (
+            f'&geom={{"type":"Polygon","coordinates":[[[{self.kw["min_lon"]},{self.kw["min_lat"]}],'
+            + f'[{self.kw["max_lon"]},{self.kw["min_lat"]}],'
+            + f'[{self.kw["max_lon"]},{self.kw["max_lat"]}],'
+            + f'[{self.kw["min_lon"]},{self.kw["max_lat"]}],'
+            + f'[{self.kw["min_lon"]},{self.kw["min_lat"]}]]]}}'
+        )
+        return f"{url_add_box}"
 
     def url_time(self):
         # add time filtering
         # convert input datetime to seconds since 1970
-        startDateTime = (pd.Timestamp(self.kw["min_time"]).tz_localize('UTC')
-                       - pd.Timestamp("1970-01-01 00:00").tz_localize('UTC')) // pd.Timedelta('1s')
-        endDateTime = (pd.Timestamp(self.kw["max_time"]).tz_localize('UTC')
-                     - pd.Timestamp("1970-01-01 00:00").tz_localize('UTC')) // pd.Timedelta('1s')
+        startDateTime = (
+            pd.Timestamp(self.kw["min_time"]).tz_localize("UTC")
+            - pd.Timestamp("1970-01-01 00:00").tz_localize("UTC")
+        ) // pd.Timedelta("1s")
+        endDateTime = (
+            pd.Timestamp(self.kw["max_time"]).tz_localize("UTC")
+            - pd.Timestamp("1970-01-01 00:00").tz_localize("UTC")
+        ) // pd.Timedelta("1s")
 
         # search by time
-        url_add_time = f'&startDateTime={startDateTime}&endDateTime={endDateTime}'
+        url_add_time = f"&startDateTime={startDateTime}&endDateTime={endDateTime}"
 
-        return f'{url_add_time}'
-
+        return f"{url_add_time}"
 
     def url_dataset_id(self, dataset_id):
-        return f'&id={dataset_id}'
+        return f"&id={dataset_id}"
 
-
-    def url_builder(self, url_base, dataset_id=None, add_region=False,
-                    add_time=False, variable=None, query=None):
+    def url_builder(
+        self,
+        url_base,
+        dataset_id=None,
+        add_region=False,
+        add_time=False,
+        variable=None,
+        query=None,
+    ):
         url = url_base
         if dataset_id is not None:
             url += self.url_dataset_id(dataset_id)
         if add_time:
             url += self.url_time()
         if variable is not None:
-            if self.axds_type == 'platform2':
+            if self.axds_type == "platform2":
                 url += self.url_variable(variable)
-            elif self.axds_type == 'layer_group':
+            elif self.axds_type == "layer_group":
                 url += self.url_query(variable)
         if add_region:
             url += self.url_region()
@@ -138,31 +119,35 @@ class AxdsReader:
 
         return url
 
-
     @property
     def urls(self):
-        '''make a list of urls for stations mode.
+        """make a list of urls for stations mode."""
+        assert (
+            self.approach is not None
+        ), "Use this property through class method `region` or `stations`"
 
-        '''
+        if not hasattr(self, "_urls"):
 
-        assert self.approach is not None, 'Use this property through class method `region` or `stations`'
-
-        if not hasattr(self, '_urls'):
-
-            if self.approach == 'region':
+            if self.approach == "region":
                 urls = []
                 if self.variables is not None:
                     for variable in self.variables:
-                        urls.append(self.url_builder(self.url_axds_type,
-                                                     variable=variable,
-                                                     add_time=True,
-                                                     add_region=True))
+                        urls.append(
+                            self.url_builder(
+                                self.url_axds_type,
+                                variable=variable,
+                                add_time=True,
+                                add_region=True,
+                            )
+                        )
                 else:
-                        urls.append(self.url_builder(self.url_axds_type,
-                                                     add_time=True,
-                                                     add_region=True))
+                    urls.append(
+                        self.url_builder(
+                            self.url_axds_type, add_time=True, add_region=True
+                        )
+                    )
 
-            elif self.approach == 'stations':
+            elif self.approach == "stations":
                 urls = []
                 # if input stations instead of dataset_ids, using different urls here
                 # if self._stations is not None:
@@ -171,7 +156,9 @@ class AxdsReader:
                         urls.append(self.url_builder(self.url_axds_type, query=station))
                 else:
                     for dataset_id in self._dataset_ids:
-                        urls.append(self.url_builder(self.url_docs_base, dataset_id=dataset_id))
+                        urls.append(
+                            self.url_builder(self.url_docs_base, dataset_id=dataset_id)
+                        )
 
             self._urls = urls
 
@@ -180,66 +167,76 @@ class AxdsReader:
     @property
     def search_results(self):
 
-        if not hasattr(self, '_search_results'):
+        if not hasattr(self, "_search_results"):
 
             # loop over urls in case we have stations
             search_results = []
             for url in self.urls:
                 res = requests.get(url, headers=self.search_headers).json()
                 # get different returns for an id docs grab vs. generic search
-#                 if isinstance(res, list):
-#                     res = res[0]
+                #                 if isinstance(res, list):
+                #                     res = res[0]
                 if isinstance(res, dict):
-                    res = res['results']
+                    res = res["results"]
                 search_results.extend(res)
             # change search_results to a dictionary to remove
             # duplicate dataset_ids
             search_results_dict = {}
             for search_result in search_results:
-                if self.axds_type == 'platform2':
-                    search_results_dict[search_result['uuid']] = search_result
-#                     search_results_dict[search_result['data']['uuid']] = search_result
-                if self.axds_type == 'layer_group':
+                if self.axds_type == "platform2":
+                    search_results_dict[search_result["uuid"]] = search_result
+                #                     search_results_dict[search_result['data']['uuid']] = search_result
+                if self.axds_type == "layer_group":
                     # switch to module search results instead of layer_group results
-                    module_uuid = search_result['data']['module_uuid']
+                    module_uuid = search_result["data"]["module_uuid"]
                     # don't repeat unnecessarily
                     if module_uuid in search_results_dict.keys():
                         continue
                     else:
-                        url_module = self.url_builder(self.url_docs_base, dataset_id=module_uuid)
-                        search_results_dict[module_uuid] = requests.get(url_module, headers=self.search_headers).json()[0]
+                        url_module = self.url_builder(
+                            self.url_docs_base, dataset_id=module_uuid
+                        )
+                        search_results_dict[module_uuid] = requests.get(
+                            url_module, headers=self.search_headers
+                        ).json()[0]
 
-            condition = (search_results_dict == {})
-            assertion = f'No datasets fit the input criteria of kw={self.kw} and variables={self.variables}'
-#             assert condition, assertion
+            condition = search_results_dict == {}
+            assertion = f"No datasets fit the input criteria of kw={self.kw} and variables={self.variables}"
+            #             assert condition, assertion
             if condition:
-                logger_axds.warning(assertion)
+                logger.warning(assertion)
                 # self._dataset_ids = []
 
             # DON'T SAVE THIS LATER, JUST FOR DEBUGGING
             self._search_results = search_results_dict
 
-#             self._dataset_ids = list(search_results_dict.keys())
+        #             self._dataset_ids = list(search_results_dict.keys())
         return self._search_results
 
-
-    def write_catalog_layer_group_entry(self, dataset, dataset_id, urlpath, layer_groups):
+    def write_catalog_layer_group_entry(
+        self, dataset, dataset_id, urlpath, layer_groups
+    ):
         try:
-            model_slug = dataset['data']['model']['slug']
+            model_slug = dataset["data"]["model"]["slug"]
         except:
-            model_slug = ''
+            model_slug = ""
 
         # these are from the module
         try:
-            label = dataset['label'].replace(':','-')
+            label = dataset["label"].replace(":", "-")
         except:
-            label = dataset['data']['short_description']
+            label = dataset["data"]["short_description"]
 
-        geospatial_lat_min, geospatial_lat_max = dataset['data']['min_lat'], dataset['data']['max_lat']
-        geospatial_lon_min, geospatial_lon_max = dataset['data']['min_lng'], dataset['data']['max_lng']
+        geospatial_lat_min, geospatial_lat_max = (
+            dataset["data"]["min_lat"],
+            dataset["data"]["max_lat"],
+        )
+        geospatial_lon_min, geospatial_lon_max = (
+            dataset["data"]["min_lng"],
+            dataset["data"]["max_lng"],
+        )
 
-        lines = \
-f'''
+        lines = f"""
   {dataset_id}:
     description: {label}
     driver: opendap
@@ -258,10 +255,8 @@ f'''
       time_coverage_start: {dataset['start_date_time']}
       time_coverage_end: {dataset['end_date_time']}
 
-'''
+"""
         return lines
-
-
 
     def write_catalog(self):
 
@@ -273,18 +268,29 @@ f'''
 
             f = open(self.catalog_name, "w")
 
-            if self.axds_type == 'platform2':
-                lines = 'sources:\n'
+            if self.axds_type == "platform2":
+                lines = "sources:\n"
                 for dataset_id, dataset in self.search_results.items():
-                    label = dataset['label'].replace(':','-')
-                    urlpath = dataset['source']['files']['data.csv.gz']['url']
-                    metavars = dataset['source']['meta']['variables']
-                    Vars, standard_names = zip(*[(key,metavars[key]['attributes']['standard_name']) for key in metavars.keys() if ('attributes' in metavars[key].keys()) and ('standard_name' in metavars[key]['attributes'])])
-                    P = shapely.wkt.loads(dataset['data']['geospatial_bounds'])
-                    geospatial_lon_min, geospatial_lat_min, geospatial_lon_max, geospatial_lat_max = P.bounds
+                    label = dataset["label"].replace(":", "-")
+                    urlpath = dataset["source"]["files"]["data.csv.gz"]["url"]
+                    metavars = dataset["source"]["meta"]["variables"]
+                    Vars, standard_names = zip(
+                        *[
+                            (key, metavars[key]["attributes"]["standard_name"])
+                            for key in metavars.keys()
+                            if ("attributes" in metavars[key].keys())
+                            and ("standard_name" in metavars[key]["attributes"])
+                        ]
+                    )
+                    P = shapely.wkt.loads(dataset["data"]["geospatial_bounds"])
+                    (
+                        geospatial_lon_min,
+                        geospatial_lat_min,
+                        geospatial_lon_max,
+                        geospatial_lat_max,
+                    ) = P.bounds
 
-                    lines += \
-f'''
+                    lines += f"""
   {dataset["uuid"]}:
     description: {label}
     driver: csv
@@ -304,34 +310,43 @@ f'''
       time_coverage_start: {dataset['start_date_time']}
       time_coverage_end: {dataset['end_date_time']}
 
-'''
+"""
 
-            elif self.axds_type == 'layer_group':
-                lines = \
-'''
+            elif self.axds_type == "layer_group":
+                lines = """
 plugins:
   source:
     - module: intake_xarray
 sources:
-'''
+"""
                 # catalog entries are by module uuid and unique to opendap urls
                 # dataset_ids are module uuids
                 for dataset_id, dataset in self.search_results.items():
 
                     # layer_groups associated with module
-                    layer_groups = dataset['data']['layer_group_info']
+                    layer_groups = dataset["data"]["layer_group_info"]
 
                     # get search results for layer_groups
                     urlpaths = []
                     for layer_group_uuid in layer_groups.keys():
-                        url_layer_group = self.url_builder(self.url_docs_base, dataset_id=layer_group_uuid)
-                        search_results_lg = requests.get(url_layer_group, headers=self.search_headers).json()[0]
+                        url_layer_group = self.url_builder(
+                            self.url_docs_base, dataset_id=layer_group_uuid
+                        )
+                        search_results_lg = requests.get(
+                            url_layer_group, headers=self.search_headers
+                        ).json()[0]
 
-                        if 'OPENDAP' in search_results_lg['data']['access_methods']:
-                            urlpaths.append(search_results_lg['source']['layers'][0]['thredds_opendap_url'][:-5])
+                        if "OPENDAP" in search_results_lg["data"]["access_methods"]:
+                            urlpaths.append(
+                                search_results_lg["source"]["layers"][0][
+                                    "thredds_opendap_url"
+                                ][:-5]
+                            )
                         else:
-                            urlpaths.append('')
-                            logger_axds.warning(f'no opendap url for module: module uuid {dataset_id}, layer_group uuid {layer_group_uuid}')
+                            urlpaths.append("")
+                            logger.warning(
+                                f"no opendap url for module: module uuid {dataset_id}, layer_group uuid {layer_group_uuid}"
+                            )
                             # DO NOT STORE ITEM IN CATALOG IF NOT OPENDAP ACCESSIBLE
                             continue
 
@@ -339,29 +354,36 @@ sources:
                     # in which case associate the layer_group uuid with the dataset
                     # since the module uuid wouldn't be unique
                     if len(set(urlpaths)) > 1:
-                        logger_axds.warning(f'there are multiple urls for module: module uuid {dataset_id}. urls: {set(urlpaths)}')
-                        for urlpath, layer_group_uuid in zip(urlpaths,layer_groups.keys()):
-                            lines += self.write_catalog_layer_group_entry(dataset, layer_group_uuid, urlpath, layer_groups)
+                        logger.warning(
+                            f"there are multiple urls for module: module uuid {dataset_id}. urls: {set(urlpaths)}"
+                        )
+                        for urlpath, layer_group_uuid in zip(
+                            urlpaths, layer_groups.keys()
+                        ):
+                            lines += self.write_catalog_layer_group_entry(
+                                dataset, layer_group_uuid, urlpath, layer_groups
+                            )
 
                     else:
                         urlpath = list(set(urlpaths))[0]
                         # use module uuid
-                        lines += self.write_catalog_layer_group_entry(dataset, dataset_id, urlpath, layer_groups)
+                        lines += self.write_catalog_layer_group_entry(
+                            dataset, dataset_id, urlpath, layer_groups
+                        )
 
             f.write(lines)
             f.close()
 
-
     @property
     def catalog(self):
 
-        if not hasattr(self, '_catalog'):
+        if not hasattr(self, "_catalog"):
 
             self.write_catalog()
             # if we already know there aren't any dataset_ids
             # don't try to read catalog
-            if (not self.search_results == {}):
-#             if (not self.dataset_ids == []) or (not self.search_results == {}):
+            if not self.search_results == {}:
+                #             if (not self.dataset_ids == []) or (not self.search_results == {}):
                 catalog = intake.open_catalog(self.catalog_name)
             else:
                 catalog = None
@@ -369,12 +391,11 @@ sources:
 
         return self._catalog
 
-
     @property
     def dataset_ids(self):
-        '''Find dataset_ids for server.'''
+        """Find dataset_ids for server."""
 
-        if not hasattr(self, '_dataset_ids'):
+        if not hasattr(self, "_dataset_ids"):
             if self.catalog is not None:
                 self._dataset_ids = list(self.catalog)
             else:
@@ -382,150 +403,178 @@ sources:
 
         return self._dataset_ids
 
-
     def meta_by_dataset(self, dataset_id):
-        '''Should this return intake-style or a row of the metadata dataframe?'''
+        """Should this return intake-style or a row of the metadata dataframe?"""
 
         return self.catalog[dataset_id]
 
-
     @property
     def meta(self):
-        '''Rearrange the individual metadata into a dataframe.'''
+        """Rearrange the individual metadata into a dataframe."""
 
-        if not hasattr(self, '_meta'):
+        if not hasattr(self, "_meta"):
 
             data = []
             for dataset_id in self.dataset_ids:
                 meta = self.meta_by_dataset(dataset_id)
-                columns = ['download_url'] + list(meta.metadata.keys())  # this only needs to be set once
+                columns = ["download_url"] + list(
+                    meta.metadata.keys()
+                )  # this only needs to be set once
                 data.append([meta.urlpath] + list(meta.metadata.values()))
             if len(self.dataset_ids) > 0:
-                self._meta = pd.DataFrame(index=self.dataset_ids, columns=columns, data=data)
+                self._meta = pd.DataFrame(
+                    index=self.dataset_ids, columns=columns, data=data
+                )
             else:
                 self._meta = None
 
         return self._meta
 
-
     def data_by_dataset(self, dataset_id):
 
-        if self.axds_type == 'platform2':
+        if self.axds_type == "platform2":
 
             # .to_dask().compute() seems faster than read but
             # should do more comparisons
             data = self.catalog[dataset_id].to_dask().compute()
-            data = data.set_index('time')
-            data = data[self.kw['min_time']:self.kw['max_time']]
+            data = data.set_index("time")
+            data = data[self.kw["min_time"] : self.kw["max_time"]]
 
-        elif self.axds_type == 'layer_group':
+        elif self.axds_type == "layer_group":
 
             if self.catalog[dataset_id].urlpath is not None:
                 try:
                     data = self.catalog[dataset_id].to_dask()
                     try:
-                        timekey = [coord for coord in data.coords if ('standard_name' in data[coord].attrs) and (data[coord].attrs['standard_name'] == 'time')]
+                        timekey = [
+                            coord
+                            for coord in data.coords
+                            if ("standard_name" in data[coord].attrs)
+                            and (data[coord].attrs["standard_name"] == "time")
+                        ]
                         assert len(timekey) > 0
                     except:
-                        timekey = [coord for coord in data.coords if ('time' in coord) or (coord=='t')]
+                        timekey = [
+                            coord
+                            for coord in data.coords
+                            if ("time" in coord) or (coord == "t")
+                        ]
                         assert len(timekey) > 0
                     timekey = timekey[0]
-                    slicedict = {timekey: slice(self.kw['min_time'],self.kw['max_time'])}
+                    slicedict = {
+                        timekey: slice(self.kw["min_time"], self.kw["max_time"])
+                    }
                     data = data.sel(slicedict)
                 except KeyError as e:
-#                     logger_axds.exception(e)
-#                     logger_axds.warning(f'data was not read in for dataset_id {dataset_id} with url path {self.catalog[dataset_id].urlpath} and description {self.catalog[dataset_id].description}.')
+                    #                     logger.exception(e)
+                    #                     logger.warning(f'data was not read in for dataset_id {dataset_id} with url path {self.catalog[dataset_id].urlpath} and description {self.catalog[dataset_id].description}.')
 
                     # try to fix key error assuming it is the following problem:
                     # KeyError: "cannot represent labeled-based slice indexer for dimension 'time' with a slice over integer positions; the index is unsorted or non-unique"
                     try:
-                        timekey = [coord for coord in data.coords if ('standard_name' in data[coord].attrs) and (data[coord].attrs['standard_name'] == 'time')]
+                        timekey = [
+                            coord
+                            for coord in data.coords
+                            if ("standard_name" in data[coord].attrs)
+                            and (data[coord].attrs["standard_name"] == "time")
+                        ]
                         assert len(timekey) > 0
                     except:
-                        timekey = [coord for coord in data.coords if ('time' in coord) or (coord=='t')]
+                        timekey = [
+                            coord
+                            for coord in data.coords
+                            if ("time" in coord) or (coord == "t")
+                        ]
                         assert len(timekey) > 0
                     timekey = timekey[0]
 
-                    slicedict = {timekey: slice(self.kw['min_time'],self.kw['max_time'])}
+                    slicedict = {
+                        timekey: slice(self.kw["min_time"], self.kw["max_time"])
+                    }
                     _, index = np.unique(data[timekey], return_index=True)
                     data = data.isel({timekey: index}).sel(slicedict)
                 except Exception as e:
-                    logger_axds.exception(e)
-                    logger_axds.warning(f'data was not read in for dataset_id {dataset_id} with url path {self.catalog[dataset_id].urlpath} and description {self.catalog[dataset_id].description}.')
+                    logger.exception(e)
+                    logger.warning(
+                        f"data was not read in for dataset_id {dataset_id} with url path {self.catalog[dataset_id].urlpath} and description {self.catalog[dataset_id].description}."
+                    )
                     data = None
             else:
                 data = None
 
         return (dataset_id, data)
-#         return (dataset_id, self.catalog[dataset_id].read())
 
+    #         return (dataset_id, self.catalog[dataset_id].read())
 
     # @property
     def data(self):
-        '''Do I need to worry about intake caching?'''
+        """Do I need to worry about intake caching?"""
 
-        if not hasattr(self, '_data'):
+        if not hasattr(self, "_data"):
 
             if self.parallel:
                 num_cores = multiprocessing.cpu_count()
                 downloads = Parallel(n_jobs=num_cores)(
-                    delayed(self.data_by_dataset)(dataset_id) for dataset_id in self.dataset_ids
+                    delayed(self.data_by_dataset)(dataset_id)
+                    for dataset_id in self.dataset_ids
                 )
             else:
                 downloads = []
                 for dataset_id in self.dataset_ids:
                     downloads.append(self.data_by_dataset(dataset_id))
 
-#             if downloads is not None:
+            #             if downloads is not None:
             dds = {dataset_id: dd for (dataset_id, dd) in downloads}
-#             else:
-#                 dds = None
+            #             else:
+            #                 dds = None
 
             self._data = dds
 
         return self._data
 
-
     def all_variables(self):
-        '''Not relevant for layer_group'''
+        """Not relevant for layer_group"""
 
-        path_fname = odg.path_variables.joinpath("parameter_group_names.txt")
-        path_csv_fname = odg.path_variables.joinpath('axds_platform2_variable_list.csv')
+        path_fname = odg.variables_path.joinpath("parameter_group_names.txt")
+        path_csv_fname = odg.variables_path.joinpath("axds_platform2_variable_list.csv")
         # read in Axiom Search parameter group names
         # save to file
         if path_csv_fname.is_file():
-            df = pd.read_csv(path_csv_fname, index_col='variable')
+            df = pd.read_csv(path_csv_fname, index_col="variable")
         else:
-            print('Please wait while the list of available variables is made. This only happens once.')
-            os.system(f'curl -sSL -H "Accept: application/json" "https://search.axds.co/v2/search" | jq -r \'.tags["Parameter Group"][] | "\(.label) \(.count)"\' > {path_fname}')
+            print(
+                "Please wait while the list of available variables is made. This only happens once."
+            )
+            os.system(
+                f'curl -sSL -H "Accept: application/json" "https://search.axds.co/v2/search" | jq -r \'.tags["Parameter Group"][] | "\(.label) \(.count)"\' > {path_fname}'
+            )
 
             # read in parameter group names
             f = open(path_fname, "r")
             parameters_temp = f.readlines()
             f.close()
-    #         parameters = [parameter.strip('\n') for parameter in parameters]
+            #         parameters = [parameter.strip('\n') for parameter in parameters]
             parameters = {}
             for parameter in parameters_temp:
-                parts = parameter.strip('\n').split()
-                name = ' '.join(parts[:-1])
+                parts = parameter.strip("\n").split()
+                name = " ".join(parts[:-1])
                 count = parts[-1]
                 parameters[name] = count
 
             df = pd.DataFrame()
-            df['variable'] = parameters.keys()
-            df['count'] = parameters.values()
-            df = df.set_index('variable')
+            df["variable"] = parameters.keys()
+            df["count"] = parameters.values()
+            df = df.set_index("variable")
             df.to_csv(path_csv_fname)
 
         return df
 
-
     def search_variables(self, variables):
-        '''Find valid variables names to use.
+        """Find valid variables names to use.
 
         Call with `search_variables()` to return the list of possible names.
         Call with `search_variables('salinity')` to return relevant names.
-        '''
+        """
 
         if not isinstance(variables, list):
             variables = [variables]
@@ -534,7 +583,7 @@ sources:
         search = f"(?i)"
         for variable in variables:
             search += f".*{variable}|"
-        search = search.strip('|')
+        search = search.strip("|")
 
         r = re.compile(search)
 
@@ -544,15 +593,14 @@ sources:
         matches = list(filter(r.match, parameters))
 
         # return parameters that match input variable strings
-        return df.loc[matches].sort_values('count', ascending=False)
-
+        return df.loc[matches].sort_values("count", ascending=False)
 
     def check_variables(self, variables, verbose=False):
 
         assertion = f'Variables are only used to filter the search for \
                     \n`axds_type="platform2". Currently, \
                     \naxds_type={self.axds_type}.'
-        assert self.axds_type == 'platform2', assertion
+        assert self.axds_type == "platform2", assertion
 
         if not isinstance(variables, list):
             variables = [variables]
@@ -565,51 +613,52 @@ sources:
         for variable in variables:
             count += [parameters.count(variable)]
 
-        condition = np.allclose(count,1)
+        condition = np.allclose(count, 1)
 
-        assertion = f'The input variables are not exact matches to parameter groups. \
+        assertion = f"The input variables are not exact matches to parameter groups. \
                      \nCheck all parameter group values with `AxdsReader().all_variables()` \
                      \nor search parameter group values with `AxdsReader().search_variables({variables})`.\
-                     \n\n Try some of the following variables:\n{str(self.search_variables(variables))}'
+                     \n\n Try some of the following variables:\n{str(self.search_variables(variables))}"
 
         assert condition, assertion
 
         if condition and verbose:
-            print('all variables are matches!')
-
+            print("all variables are matches!")
 
     # Search for stations by region
+
+
 class region(AxdsReader):
-#     def region(self, kw, axds_type='platform2', variables=None):
-#         '''HOW TO INCORPORATE VARIABLE NAMES?'''
+    #     def region(self, kw, axds_type='platform2', variables=None):
+    #         '''HOW TO INCORPORATE VARIABLE NAMES?'''
 
     def __init__(self, kwargs):
-        assert isinstance(kwargs, dict), 'input arguments as dictionary'
-        ax_kwargs = {'catalog_name': kwargs.get('catalog_name', None),
-                     'parallel': kwargs.get('parallel', True),
-                     'axds_type': kwargs.get('axds_type', 'platform2')
-                    }
+        assert isinstance(kwargs, dict), "input arguments as dictionary"
+        ax_kwargs = {
+            "catalog_name": kwargs.get("catalog_name", None),
+            "parallel": kwargs.get("parallel", True),
+            "axds_type": kwargs.get("axds_type", "platform2"),
+        }
         AxdsReader.__init__(self, **ax_kwargs)
 
-        kw = kwargs['kw']
-        variables = kwargs.get('variables', None)
+        kw = kwargs["kw"]
+        variables = kwargs.get("variables", None)
 
-        self.approach = 'region'
+        self.approach = "region"
 
         self._stations = None
 
-#         # can be 'platform2' or 'layer_group'
-#         assert axds_type in ['platform2','layer_group'], 'variable `axds_type` must be "platform2" or "layer_group"'
-#         self.axds_type = axds_type
+        #         # can be 'platform2' or 'layer_group'
+        #         assert axds_type in ['platform2','layer_group'], 'variable `axds_type` must be "platform2" or "layer_group"'
+        #         self.axds_type = axds_type
 
-#         self.url_axds_type = f'{self.url_search_base}&type={self.axds_type}'
-
+        #         self.url_axds_type = f'{self.url_search_base}&type={self.axds_type}'
 
         # run checks for KW
         # check for lon/lat values and time
         self.kw = kw
 
-# #         self.data_type = data_type
+        # #         self.data_type = data_type
         if (variables is not None) and (not isinstance(variables, list)):
             variables = [variables]
 
@@ -617,57 +666,59 @@ class region(AxdsReader):
         if variables is not None:
             self.check_variables(variables)
 
-
         self.variables = variables
+
+
 #         # DOESN'T CURRENTLY LIMIT WHICH VARIABLES WILL BE FOUND ON EACH SERVER
 
 #         return self
 
 
 class stations(AxdsReader):
-#     def stations(self, dataset_ids=None, stations=None, kw=None, axds_type='platform2'):
-#         '''
+    #     def stations(self, dataset_ids=None, stations=None, kw=None, axds_type='platform2'):
+    #         '''
 
-#         Use keyword dataset_ids if you already know the database-
-#         specific ids. Otherwise, use the keyword stations and the
-#         database-specific ids will be searched for. The station
-#         ids can be input as something like "TABS B" and will be
-#         searched for as "TABS AND B" and has pretty good success.
+    #         Use keyword dataset_ids if you already know the database-
+    #         specific ids. Otherwise, use the keyword stations and the
+    #         database-specific ids will be searched for. The station
+    #         ids can be input as something like "TABS B" and will be
+    #         searched for as "TABS AND B" and has pretty good success.
 
-#         Treat dataset_ids and stations the same since either way we
-#         need to search for them. Have both to match the erddap
-#         syntax.
+    #         Treat dataset_ids and stations the same since either way we
+    #         need to search for them. Have both to match the erddap
+    #         syntax.
 
-#         WHAT ABOUT VARIABLES?
-#         '''
+    #         WHAT ABOUT VARIABLES?
+    #         '''
 
     def __init__(self, kwargs):
-        assert isinstance(kwargs, dict), 'input arguments as dictionary'
-        ax_kwargs = {'catalog_name': kwargs.get('catalog_name', None),
-                     'parallel': kwargs.get('parallel', True),
-                     'axds_type': kwargs.get('axds_type', 'platform2')}
+        assert isinstance(kwargs, dict), "input arguments as dictionary"
+        ax_kwargs = {
+            "catalog_name": kwargs.get("catalog_name", None),
+            "parallel": kwargs.get("parallel", True),
+            "axds_type": kwargs.get("axds_type", "platform2"),
+        }
         AxdsReader.__init__(self, **ax_kwargs)
 
-        kw = kwargs.get('kw', None)
-        dataset_ids = kwargs.get('dataset_ids', None)
-        stations = kwargs.get('stations', [])
+        kw = kwargs.get("kw", None)
+        dataset_ids = kwargs.get("dataset_ids", None)
+        stations = kwargs.get("stations", [])
 
-        self.approach = 'stations'
+        self.approach = "stations"
 
+        #         self.catalog_name = os.path.join('..','catalogs',f'catalog_stations_{pd.Timestamp.now().isoformat()[:19]}.yml')
 
-#         self.catalog_name = os.path.join('..','catalogs',f'catalog_stations_{pd.Timestamp.now().isoformat()[:19]}.yml')
-
-#         # we want all the data associated with stations
-#         self.standard_names = None
+        #         # we want all the data associated with stations
+        #         self.standard_names = None
 
         # UPDATE SINCE NOW THERE IS A DIFFERENCE BETWEEN STATION AND DATASET
         if dataset_ids is not None:
             if not isinstance(dataset_ids, list):
                 dataset_ids = [dataset_ids]
-#             self._stations = dataset_ids
+            #             self._stations = dataset_ids
             self._dataset_ids = dataset_ids
 
-#         assert (if dataset_ids is not None)
+        #         assert (if dataset_ids is not None)
         # assert that dataset_ids can't be something if axds_type is layer_group
         # use stations instead, and don't use module uuid, use layer_group uuid
 
@@ -676,13 +727,12 @@ class stations(AxdsReader):
                 stations = [stations]
         self._stations = stations
 
-#         self.dataset_ids
+        #         self.dataset_ids
 
         self.variables = None
 
-
         # CHECK FOR KW VALUES AS TIMES
         if kw is None:
-            kw = {'min_time': '1900-01-01', 'max_time': '2100-12-31'}
+            kw = {"min_time": "1900-01-01", "max_time": "2100-12-31"}
 
         self.kw = kw

--- a/ocean_data_gateway/readers/erddap.py
+++ b/ocean_data_gateway/readers/erddap.py
@@ -1,61 +1,44 @@
-from erddapy import ERDDAP
-from joblib import Parallel, delayed
+import logging
 import multiprocessing
+import re
+
+import numpy as np
 import pandas as pd
 import xarray as xr
-import logging
-import os
-import re
-import numpy as np
-import pathlib
+from erddapy import ERDDAP
+from joblib import Parallel, delayed
+
 import ocean_data_gateway as odg
 
 
-# Capture warnings in log
-logging.captureWarnings(True)
-
-# formatting for logfile
-formatter = logging.Formatter('%(asctime)s %(message)s','%a %b %d %H:%M:%S %Z %Y')
-log_name = 'reader_erddap'
-loglevel=logging.WARNING
-path_logs_reader = odg.path_logs.joinpath(f'{log_name}.log')
-
-# set up logger file
-handler = logging.FileHandler(path_logs_reader)
-handler.setFormatter(formatter)
-logger_erd = logging.getLogger(log_name)
-logger_erd.setLevel(loglevel)
-logger_erd.addHandler(handler)
+logger = logging.getLogger(__name__)
 
 # this can be queried with
 # search.ErddapReader.reader
-reader = 'erddap'
+reader = "erddap"
 
 
 class ErddapReader:
-
-
-    def __init__(self, known_server='ioos', protocol=None, server=None, parallel=True):
-
-#         # run checks for KW
-#         self.kw = kw
-
+    def __init__(self, known_server="ioos", protocol=None, server=None, parallel=True):
         self.parallel = parallel
 
-
         # either select a known server or input protocol and server string
-        if known_server == 'ioos':
-            protocol = 'tabledap'
-            server = 'http://erddap.sensors.ioos.us/erddap'
-        elif known_server == 'coastwatch':
-            protocol = 'griddap'
-            server = 'http://coastwatch.pfeg.noaa.gov/erddap'
+        if known_server == "ioos":
+            protocol = "tabledap"
+            server = "http://erddap.sensors.ioos.us/erddap"
+        elif known_server == "coastwatch":
+            protocol = "griddap"
+            server = "http://coastwatch.pfeg.noaa.gov/erddap"
         elif known_server is not None:
-            statement = 'either select a known server or input protocol and server string'
+            statement = (
+                "either select a known server or input protocol and server string"
+            )
             assert (protocol is not None) & (server is not None), statement
         else:
-            known_server = server.strip('/erddap').strip('http://').replace('.','_')
-            statement = 'either select a known server or input protocol and server string'
+            known_server = server.strip("/erddap").strip("http://").replace(".", "_")
+            statement = (
+                "either select a known server or input protocol and server string"
+            )
             assert (protocol is not None) & (server is not None), statement
 
         self.known_server = known_server
@@ -64,32 +47,41 @@ class ErddapReader:
         self.e.server = server
 
         # columns for metadata
-        self.columns = ['geospatial_lat_min', 'geospatial_lat_max',
-               'geospatial_lon_min', 'geospatial_lon_max',
-               'time_coverage_start', 'time_coverage_end',
-               'defaultDataQuery', 'subsetVariables',  # first works for timeseries sensors, 2nd for gliders
-               'keywords',  # for hf radar
-               'id', 'infoUrl', 'institution', 'featureType', 'source', 'sourceUrl']
+        self.columns = [
+            "geospatial_lat_min",
+            "geospatial_lat_max",
+            "geospatial_lon_min",
+            "geospatial_lon_max",
+            "time_coverage_start",
+            "time_coverage_end",
+            "defaultDataQuery",
+            "subsetVariables",  # first works for timeseries sensors, 2nd for gliders
+            "keywords",  # for hf radar
+            "id",
+            "infoUrl",
+            "institution",
+            "featureType",
+            "source",
+            "sourceUrl",
+        ]
 
         # name
-        self.name = f'erddap_{known_server}'
+        self.name = f"erddap_{known_server}"
 
-        self.reader = 'ErddapReader'
+        self.reader = "ErddapReader"
 
-# #         self.data_type = data_type
-#         self.standard_names = standard_names
-#         # DOESN'T CURRENTLY LIMIT WHICH VARIABLES WILL BE FOUND ON EACH SERVER
-
-
+    # #         self.data_type = data_type
+    #         self.standard_names = standard_names
+    #         # DOESN'T CURRENTLY LIMIT WHICH VARIABLES WILL BE FOUND ON EACH SERVER
 
     @property
     def dataset_ids(self):
-        '''Find dataset_ids for server.'''
+        """Find dataset_ids for server."""
 
-        if not hasattr(self, '_dataset_ids'):
+        if not hasattr(self, "_dataset_ids"):
 
             # This should be a region search
-            if self.approach == 'region':
+            if self.approach == "region":
 
                 # find all the dataset ids which we will use to get the data
                 # This limits the search to our keyword arguments in kw which should
@@ -99,82 +91,98 @@ class ErddapReader:
                     for variable in self.variables:
 
                         # find and save all dataset_ids associated with variable
-                        search_url = self.e.get_search_url(response="csv", **self.kw,
-                                                           variableName=variable,
-                                                           items_per_page=10000)
+                        search_url = self.e.get_search_url(
+                            response="csv",
+                            **self.kw,
+                            variableName=variable,
+                            items_per_page=10000,
+                        )
 
                         try:
                             search = pd.read_csv(search_url)
                             dataset_ids.extend(search["Dataset ID"])
                         except Exception as e:
-                            logger_erd.exception(e)
-                            logger_erd.warning(f"variable {variable} was not found in the search")
-                            logger_erd.warning(f'search_url: {search_url}')
+                            logger.exception(e)
+                            logger.warning(
+                                f"variable {variable} was not found in the search"
+                            )
+                            logger.warning(f"search_url: {search_url}")
 
                 else:
 
                     # find and save all dataset_ids associated with variable
-                    search_url = self.e.get_search_url(response="csv", **self.kw,
-                                                       items_per_page=10000)
+                    search_url = self.e.get_search_url(
+                        response="csv", **self.kw, items_per_page=10000
+                    )
 
                     try:
                         search = pd.read_csv(search_url)
                         dataset_ids.extend(search["Dataset ID"])
                     except Exception as e:
-                        logger_erd.exception(e)
-                        logger_erd.warning(f"nothing found in the search")
-                        logger_erd.warning(f'search_url: {search_url}')
-
+                        logger.exception(e)
+                        logger.warning("nothing found in the search")
+                        logger.warning(f"search_url: {search_url}")
 
                 # only need a dataset id once since we will check them each for all standard_names
                 self._dataset_ids = list(set(dataset_ids))
 
             # This should be a search for the station names
-            elif self.approach == 'stations':
-#             elif self._stations is not None:
+            elif self.approach == "stations":
+                #             elif self._stations is not None:
 
                 # search by station name for each of stations
                 dataset_ids = []
                 for station in self._stations:
                     # if station has more than one word, AND will be put between to search for multiple
                     # terms together
-                    url = self.e.get_search_url(response="csv", items_per_page=5, search_for=station)
+                    url = self.e.get_search_url(
+                        response="csv", items_per_page=5, search_for=station
+                    )
 
                     try:
                         df = pd.read_csv(url)
                     except Exception as e:
-                        logger_erd.exception(e)
-                        logger_erd.warning(f'search url {url} did not work for station {station}.')
+                        logger.exception(e)
+                        logger.warning(
+                            f"search url {url} did not work for station {station}."
+                        )
                         continue
 
                     # first try for exact station match
                     try:
-                        dataset_id = [dataset_id for dataset_id in df['Dataset ID'] if station.lower() in dataset_id.lower().split('_')][0]
+                        dataset_id = [
+                            dataset_id
+                            for dataset_id in df["Dataset ID"]
+                            if station.lower() in dataset_id.lower().split("_")
+                        ][0]
 
                     # if that doesn't work, trying for more general match and just take first returned option
                     except Exception as e:
-                        logger_erd.exception(e)
-                        logger_erd.warning('When searching for a dataset id to match station name %s, the first attempt to match the id did not work.' % (station))
-                        dataset_id = df.iloc[0]['Dataset ID']
+                        logger.exception(e)
+                        logger.warning(
+                            "When searching for a dataset id to match station name %s, the first attempt to match the id did not work."
+                            % (station)
+                        )
+                        dataset_id = df.iloc[0]["Dataset ID"]
 
-#                         if 'tabs' in org_id:  # don't split
-#                             axiom_id = [axiom_id for axiom_id in df['Dataset ID'] if org_id.lower() == axiom_id.lower()]
-#                         else:
-#                             axiom_id = [axiom_id for axiom_id in df['Dataset ID'] if org_id.lower() in axiom_id.lower().split('_')][0]
+                    #                         if 'tabs' in org_id:  # don't split
+                    #                             axiom_id = [axiom_id for axiom_id in df['Dataset ID'] if org_id.lower() == axiom_id.lower()]
+                    #                         else:
+                    #                             axiom_id = [axiom_id for axiom_id in df['Dataset ID'] if org_id.lower() in axiom_id.lower().split('_')][0]
 
-#                     except:
-#                         dataset_id = None
+                    #                     except:
+                    #                         dataset_id = None
 
                     dataset_ids.append(dataset_id)
 
                 self._dataset_ids = list(set(dataset_ids))
 
             else:
-                logger_erd.warning('Neither stations nor region approach were used in function dataset_ids.')
-
+                logger.warning(
+                    "Neither stations nor region approach were used in function dataset_ids."
+                )
 
         return self._dataset_ids
-
 
     def meta_by_dataset(self, dataset_id):
 
@@ -182,8 +190,8 @@ class ErddapReader:
         try:
             info = pd.read_csv(info_url)
         except Exception as e:
-            logger_erd.exception(e)
-            logger_erd.warning(f'Could not read info from {info_url}')
+            logger.exception(e)
+            logger.warning(f"Could not read info from {info_url}")
             return {dataset_id: []}
 
         items = []
@@ -191,59 +199,66 @@ class ErddapReader:
         for col in self.columns:
 
             try:
-                item = info[info['Attribute Name'] == col]['Value'].values[0]
-                dtype = info[info['Attribute Name'] == col]['Data Type'].values[0]
+                item = info[info["Attribute Name"] == col]["Value"].values[0]
+                dtype = info[info["Attribute Name"] == col]["Data Type"].values[0]
             except:
-                if col == 'featureType':
+                if col == "featureType":
                     # this column is not present in HF Radar metadata but want it to
                     # map to data_type, so input 'grid' in that case.
-                    item = 'grid'
+                    item = "grid"
                 else:
-                    item = 'NA'
+                    item = "NA"
 
-            if dtype == 'String':
+            if dtype == "String":
                 pass
-            elif dtype == 'double':
+            elif dtype == "double":
                 item = float(item)
-            elif dtype == 'int':
+            elif dtype == "int":
                 item = int(item)
             items.append(item)
 
-#         if self.standard_names is not None:
-#             # In case the variable is named differently from the standard names,
-#             # we back out the variable names here for each dataset. This also only
-#             # returns those names for which there is data in the dataset.
-#             varnames = self.e.get_var_by_attr(
-#                 dataset_id=dataset_id,
-#                 standard_name=lambda v: v in self.standard_names
-#             )
-#         else:
-#             varnames = None
+        #         if self.standard_names is not None:
+        #             # In case the variable is named differently from the standard names,
+        #             # we back out the variable names here for each dataset. This also only
+        #             # returns those names for which there is data in the dataset.
+        #             varnames = self.e.get_var_by_attr(
+        #                 dataset_id=dataset_id,
+        #                 standard_name=lambda v: v in self.standard_names
+        #             )
+        #         else:
+        #             varnames = None
 
         ## include download link ##
         self.e.dataset_id = dataset_id
-        if self.e.protocol == 'tabledap':
+        if self.e.protocol == "tabledap":
             if self.variables is not None:
-                self.e.variables = ["time","longitude", "latitude", "station"] + self.variables
+                self.e.variables = [
+                    "time",
+                    "longitude",
+                    "latitude",
+                    "station",
+                ] + self.variables
             # set the same time restraints as before
-            self.e.constraints = {'time<=': self.kw['max_time'], 'time>=': self.kw['min_time'],}
-            download_url = self.e.get_download_url(response='csvp')
+            self.e.constraints = {
+                "time<=": self.kw["max_time"],
+                "time>=": self.kw["min_time"],
+            }
+            download_url = self.e.get_download_url(response="csvp")
 
-        elif self.e.protocol == 'griddap':
+        elif self.e.protocol == "griddap":
             # the search terms that can be input for tabledap do not work for griddap
             # in erddapy currently. Instead, put together an opendap link and then
             # narrow the dataset with xarray.
             # get opendap link
-            download_url = self.e.get_download_url(response='opendap')
+            download_url = self.e.get_download_url(response="opendap")
 
         # add erddap server name
         return {dataset_id: [self.e.server, download_url] + items + [self.variables]}
 
-
     @property
     def meta(self):
 
-        if not hasattr(self, '_meta'):
+        if not hasattr(self, "_meta"):
 
             if self.parallel:
 
@@ -251,7 +266,8 @@ class ErddapReader:
                 # run in parallel to save time
                 num_cores = multiprocessing.cpu_count()
                 downloads = Parallel(n_jobs=num_cores)(
-                    delayed(self.meta_by_dataset)(dataset_id) for dataset_id in self.dataset_ids
+                    delayed(self.meta_by_dataset)(dataset_id)
+                    for dataset_id in self.dataset_ids
                 )
 
             else:
@@ -262,24 +278,28 @@ class ErddapReader:
 
             # make dict from individual dicts
             from collections import ChainMap
+
             meta = dict(ChainMap(*downloads))
 
             # Make dataframe of metadata
             # variable names are the column names for the dataframe
-            self._meta = pd.DataFrame.from_dict(meta, orient='index',
-                                                columns=['database','download_url'] \
-                                                + self.columns + ['variable names'])
+            self._meta = pd.DataFrame.from_dict(
+                meta,
+                orient="index",
+                columns=["database", "download_url"]
+                + self.columns
+                + ["variable names"],
+            )
 
         return self._meta
 
-
     def data_by_dataset(self, dataset_id):
 
-        download_url = self.meta.loc[dataset_id, 'download_url']
+        download_url = self.meta.loc[dataset_id, "download_url"]
         # data variables in ds that are not the variables we searched for
-#         varnames = self.meta.loc[dataset_id, 'variable names']
+        #         varnames = self.meta.loc[dataset_id, 'variable names']
 
-        if self.e.protocol == 'tabledap':
+        if self.e.protocol == "tabledap":
 
             try:
 
@@ -288,34 +308,42 @@ class ErddapReader:
                 dd = pd.read_csv(download_url, index_col=0, parse_dates=True)
 
                 # Drop cols and rows that are only NaNs.
-                dd = dd.dropna(axis='index', how='all').dropna(axis='columns', how='all')
+                dd = dd.dropna(axis="index", how="all").dropna(
+                    axis="columns", how="all"
+                )
 
                 if self.variables is not None:
                     # check to see if there is any actual data
                     # this is a bit convoluted because the column names are the variable names
                     # plus units so can't match 1 to 1.
-                    datacols = 0  # number of columns that represent data instead of metadata
+                    datacols = (
+                        0  # number of columns that represent data instead of metadata
+                    )
                     for col in dd.columns:
-                        datacols += [varname in col for varname in self.variables].count(True)
+                        datacols += [
+                            varname in col for varname in self.variables
+                        ].count(True)
                     # if no datacols, we can skip this one.
                     if datacols == 0:
                         dd = None
 
             except Exception as e:
-                logger_erd.exception(e)
-                logger_erd.warning('no data to be read in for %s' % dataset_id)
+                logger.exception(e)
+                logger.warning("no data to be read in for %s" % dataset_id)
                 dd = None
 
-        elif self.e.protocol == 'griddap':
+        elif self.e.protocol == "griddap":
 
             try:
-                dd = xr.open_dataset(download_url, chunks='auto').sel(time=slice(self.kw['min_time'],self.kw['max_time']))
+                dd = xr.open_dataset(download_url, chunks="auto").sel(
+                    time=slice(self.kw["min_time"], self.kw["max_time"])
+                )
 
-                if ('min_lat' in self.kw) and ('max_lat' in self.kw):
-                    dd = dd.sel(latitude=slice(self.kw['min_lat'],self.kw['max_lat']))
+                if ("min_lat" in self.kw) and ("max_lat" in self.kw):
+                    dd = dd.sel(latitude=slice(self.kw["min_lat"], self.kw["max_lat"]))
 
-                if ('min_lon' in self.kw) and ('max_lon' in self.kw):
-                    dd = dd.sel(longitude=slice(self.kw['min_lon'],self.kw['max_lon']))
+                if ("min_lon" in self.kw) and ("max_lon" in self.kw):
+                    dd = dd.sel(longitude=slice(self.kw["min_lon"], self.kw["max_lon"]))
 
                 # use variable names to drop other variables (should. Ido this?)
                 if self.variables is not None:
@@ -323,12 +351,11 @@ class ErddapReader:
                     dd = dd.drop_vars(l)
 
             except Exception as e:
-                logger_erd.exception(e)
-                logger_erd.warning('no data to be read in for %s' % dataset_id)
+                logger.exception(e)
+                logger.warning("no data to be read in for %s" % dataset_id)
                 dd = None
 
         return (dataset_id, dd)
-
 
     # @property
     def data(self):
@@ -338,55 +365,58 @@ class ErddapReader:
         if self.parallel:
             num_cores = multiprocessing.cpu_count()
             downloads = Parallel(n_jobs=num_cores)(
-                delayed(self.data_by_dataset)(dataset_id) for dataset_id in self.dataset_ids
+                delayed(self.data_by_dataset)(dataset_id)
+                for dataset_id in self.dataset_ids
             )
         else:
             downloads = []
             for dataset_id in self.dataset_ids:
                 downloads.append(self.data_by_dataset(dataset_id))
 
-#             if downloads is not None:
+        #             if downloads is not None:
         dds = {dataset_id: dd for (dataset_id, dd) in downloads}
-#             else:
-#                 dds = None
+        #             else:
+        #                 dds = None
 
         return dds
         # self._data = dds
 
         # return self._data
 
-
-    def count(self,url):
+    def count(self, url):
         try:
             return len(pd.read_csv(url))
         except:
             return np.nan
 
-
     def all_variables(self):
-        '''Return a list of all possible variables.'''
+        """Return a list of all possible variables."""
 
-        path_name_counts = odg.path_variables.joinpath(f'erddap_variable_list_{self.known_server}.csv')
+        path_name_counts = odg.variables_path.joinpath(
+            f"erddap_variable_list_{self.known_server}.csv"
+        )
 
         if path_name_counts.is_file():
-            return pd.read_csv(path_name_counts, index_col='variable')
+            return pd.read_csv(path_name_counts, index_col="variable")
         else:
-            print('Please wait while the list of available variables is made. This only happens once but could take 10 minutes.')
+            print(
+                "Please wait while the list of available variables is made. This only happens once but could take 10 minutes."
+            )
             # This took 10 min running in parallel for ioos
             # 2 min for coastwatch
-            url = f'{self.e.server}/categorize/variableName/index.csv?page=1&itemsPerPage=100000'
+            url = f"{self.e.server}/categorize/variableName/index.csv?page=1&itemsPerPage=100000"
             df = pd.read_csv(url)
-#             counts = []
-#             for url in df.URL:
-#                 counts.append(self.count(url))
+            #             counts = []
+            #             for url in df.URL:
+            #                 counts.append(self.count(url))
             num_cores = multiprocessing.cpu_count()
             counts = Parallel(n_jobs=num_cores)(
                 delayed(self.count)(url) for url in df.URL
             )
             dfnew = pd.DataFrame()
-            dfnew['variable'] = df['Category']
-            dfnew['count'] = counts
-            dfnew = dfnew.set_index('variable')
+            dfnew["variable"] = df["Category"]
+            dfnew["count"] = counts
+            dfnew = dfnew.set_index("variable")
             # remove nans
             if (dfnew.isnull().sum() > 0).values:
                 dfnew = dfnew[~dfnew.isnull().values].astype(int)
@@ -394,13 +424,12 @@ class ErddapReader:
 
         return dfnew
 
-
     def search_variables(self, variables):
-        '''Find valid variables names to use.
+        """Find valid variables names to use.
 
         Call with `search_variables()` to return the list of possible names.
         Call with `search_variables('salinity')` to return relevant names.
-        '''
+        """
 
         if not isinstance(variables, list):
             variables = [variables]
@@ -409,7 +438,7 @@ class ErddapReader:
         search = f"(?i)"
         for variable in variables:
             search += f".*{variable}|"
-        search = search.strip('|')
+        search = search.strip("|")
 
         r = re.compile(search)
 
@@ -420,15 +449,14 @@ class ErddapReader:
         matches = list(filter(r.match, parameters))
 
         # return parameters that match input variable strings
-        return df.loc[matches].sort_values('count', ascending=False)
-
+        return df.loc[matches].sort_values("count", ascending=False)
 
     def check_variables(self, variables, verbose=False):
 
         if not isinstance(variables, list):
             variables = [variables]
 
-#         parameters = list(self.all_variables().keys())
+        #         parameters = list(self.all_variables().keys())
         parameters = list(self.all_variables().index)
 
         # for a variable to exactly match a parameter
@@ -437,35 +465,35 @@ class ErddapReader:
         for variable in variables:
             count += [parameters.count(variable)]
 
-        condition = np.allclose(count,1)
+        condition = np.allclose(count, 1)
 
-        assertion = f'The input variables are not exact matches to ok variables for known_server {self.known_server}. \
+        assertion = f"The input variables are not exact matches to ok variables for known_server {self.known_server}. \
                      \nCheck all parameter group values with `ErddapReader().all_variables()` \
                      \nor search parameter group values with `ErddapReader().search_variables({variables})`.\
-                     \n\n Try some of the following variables:\n{str(self.search_variables(variables))}'# \
-#                      \nor run `ErddapReader().check_variables("{variables}")'
+                     \n\n Try some of the following variables:\n{str(self.search_variables(variables))}"  # \
+        #                      \nor run `ErddapReader().check_variables("{variables}")'
         assert condition, assertion
 
         if condition and verbose:
-            print('all variables are matches!')
+            print("all variables are matches!")
 
 
-    # Search for stations by region
+# Search for stations by region
 class region(ErddapReader):
-#     def region(self, kw, variables=None):
-
     def __init__(self, kwargs):
-        assert isinstance(kwargs, dict), 'input arguments as dictionary'
-        er_kwargs = {'known_server': kwargs.get('known_server', 'ioos'),
-                     'protocol': kwargs.get('protocol', None),
-                     'server': kwargs.get('server', None),
-                     'parallel': kwargs.get('parallel', True)}
+        assert isinstance(kwargs, dict), "input arguments as dictionary"
+        er_kwargs = {
+            "known_server": kwargs.get("known_server", "ioos"),
+            "protocol": kwargs.get("protocol", None),
+            "server": kwargs.get("server", None),
+            "parallel": kwargs.get("parallel", True),
+        }
         ErddapReader.__init__(self, **er_kwargs)
 
-        kw = kwargs['kw']
-        variables = kwargs.get('variables', None)
+        kw = kwargs["kw"]
+        variables = kwargs.get("variables", None)
 
-        self.approach = 'region'
+        self.approach = "region"
 
         self._stations = None
 
@@ -486,39 +514,39 @@ class region(ErddapReader):
 #         if not isinstance(standard_names, list):
 #             standard_names = [standard_names]
 #         self.standard_names = standard_names
-    # DOESN'T CURRENTLY LIMIT WHICH VARIABLES WILL BE FOUND ON EACH SERVER
+# DOESN'T CURRENTLY LIMIT WHICH VARIABLES WILL BE FOUND ON EACH SERVER
 
 #     return self
 
 
 class stations(ErddapReader):
-#     def stations(self, dataset_ids=None, stations=None, kw=None):
-#         '''
-
-#         Use keyword dataset_ids if you already know the database-
-#         specific ids. Otherwise, use the keyword stations and the
-#         database-specific ids will be searched for. The station
-#         ids can be input as something like "TABS B" and will be
-#         searched for as "TABS AND B" and has pretty good success.
-#         '''
-
+    #     def stations(self, dataset_ids=None, stations=None, kw=None):
+    #         '''
+    #         Use keyword dataset_ids if you already know the database-
+    #         specific ids. Otherwise, use the keyword stations and the
+    #         database-specific ids will be searched for. The station
+    #         ids can be input as something like "TABS B" and will be
+    #         searched for as "TABS AND B" and has pretty good success.
+    #         '''
 
     def __init__(self, kwargs):
-        assert isinstance(kwargs, dict), 'input arguments as dictionary'
-        er_kwargs = {'known_server': kwargs.get('known_server', 'ioos'),
-                     'protocol': kwargs.get('protocol', None),
-                     'server': kwargs.get('server', None),
-                     'parallel': kwargs.get('parallel', True)}
+        assert isinstance(kwargs, dict), "input arguments as dictionary"
+        er_kwargs = {
+            "known_server": kwargs.get("known_server", "ioos"),
+            "protocol": kwargs.get("protocol", None),
+            "server": kwargs.get("server", None),
+            "parallel": kwargs.get("parallel", True),
+        }
         ErddapReader.__init__(self, **er_kwargs)
 
-        kw = kwargs.get('kw', None)
-        dataset_ids = kwargs.get('dataset_ids', None)
-        stations = kwargs.get('stations', [])
+        kw = kwargs.get("kw", None)
+        dataset_ids = kwargs.get("dataset_ids", None)
+        stations = kwargs.get("stations", [])
 
-        self.approach = 'stations'
+        self.approach = "stations"
 
         # we want all the data associated with stations
-#         self.standard_names = None
+        #         self.standard_names = None
         self.variables = None
 
         if dataset_ids is not None:
@@ -534,11 +562,8 @@ class stations(ErddapReader):
         else:
             self._stations = stations
 
-
-
-
         # CHECK FOR KW VALUES AS TIMES
         if kw is None:
-            kw = {'min_time': '1900-01-01', 'max_time': '2100-12-31'}
+            kw = {"min_time": "1900-01-01", "max_time": "2100-12-31"}
 
         self.kw = kw

--- a/ocean_data_gateway/readers/local.py
+++ b/ocean_data_gateway/readers/local.py
@@ -1,48 +1,32 @@
+import hashlib
 import logging
+import multiprocessing
 import os
+
 import intake
 import pandas as pd
-import hashlib
 from joblib import Parallel, delayed
-import multiprocessing
-import pathlib
+
 import ocean_data_gateway as odg
 
 
-# Capture warnings in log
-logging.captureWarnings(True)
-
-# formatting for logfile
-formatter = logging.Formatter('%(asctime)s %(message)s','%a %b %d %H:%M:%S %Z %Y')
-log_name = 'reader_local'
-loglevel=logging.WARNING
-path_logs_reader = odg.path_logs.joinpath(f'{log_name}.log')
-
-# set up logger file
-handler = logging.FileHandler(path_logs_reader)
-handler.setFormatter(formatter)
-logger_local = logging.getLogger(log_name)
-logger_local.setLevel(loglevel)
-logger_local.addHandler(handler)
+logger = logging.getLogger(__name__)
 
 # this can be queried with
 # search.LocalReader.reader
-reader = 'local'
-
+reader = "local"
 
 
 class LocalReader:
-
-
     def __init__(self, parallel=True, catalog_name=None, filenames=None, kw=None):
 
         self.parallel = parallel
 
         if catalog_name is None:
-            name = f'{pd.Timestamp.now().isoformat()}'
+            name = f"{pd.Timestamp.now().isoformat()}"
             hash_name = hashlib.sha256(name.encode()).hexdigest()[:7]
-            path_catalog = odg.path_catalogs.joinpath(f'catalog_{hash_name}.yml')
-            self.catalog_name = path_catalog#.name
+            catalog_path = odg.catalogs_path.joinpath(f"catalog_{hash_name}.yml")
+            self.catalog_name = catalog_path
         else:
             self.catalog_name = catalog_name
             # if catalog_name already exists, read it in to save time
@@ -53,20 +37,20 @@ class LocalReader:
         self.filenames = filenames
 
         if kw is None:
-            kw = {'min_time': '1900-01-01', 'max_time': '2100-12-31'}
+            kw = {"min_time": "1900-01-01", "max_time": "2100-12-31"}
 
         self.kw = kw
 
-        if (filenames == None) and (catalog_name == None):
+        if (filenames is None) and (catalog_name is None):
             self._dataset_ids = []
-            logger_local.warning('no datasets for LocalReader with catalog_name {catalog_name} and filenames {filenames}.')
+            logger.warning(
+                f"no datasets for LocalReader with catalog_name {catalog_name} and filenames {filenames}."
+            )
 
         # name
-        self.name = 'local'
+        self.name = "local"
 
-        self.reader = 'LocalReader'
-
-
+        self.reader = "LocalReader"
 
     def write_catalog(self):
 
@@ -75,82 +59,93 @@ class LocalReader:
             return
 
         else:
-            lines = 'sources:\n'
+            lines = "sources:\n"
 
             for filename in self.filenames:
 
-                if 'csv' in filename:
+                if "csv" in filename:
                     file_intake = intake.open_csv(filename)
                     data = file_intake.read()
-                    metadata = {'variables': list(data.columns.values),
-                                'geospatial_lon_min': float(data['longitude'].min()),
-                                'geospatial_lat_min': float(data['latitude'].min()),
-                                'geospatial_lon_max': float(data['longitude'].max()),
-                                'geospatial_lat_max': float(data['latitude'].max()),
-                                'time_coverage_start': data['time'].min(),
-                                'time_coverage_end': data['time'].max()}
+                    metadata = {
+                        "variables": list(data.columns.values),
+                        "geospatial_lon_min": float(data["longitude"].min()),
+                        "geospatial_lat_min": float(data["latitude"].min()),
+                        "geospatial_lon_max": float(data["longitude"].max()),
+                        "geospatial_lat_max": float(data["latitude"].max()),
+                        "time_coverage_start": data["time"].min(),
+                        "time_coverage_end": data["time"].max(),
+                    }
                     file_intake.metadata = metadata
 
-                elif 'nc' in filename:
+                elif "nc" in filename:
                     file_intake = intake.open_netcdf(filename)
                     data = file_intake.read()
                     coords = list(data.coords.keys())
-                    timekey = [coord for coord in coords
-                                if ('time' in data[coord].attrs.values())
-                                or ('T' in data[coord].attrs.values())]
+                    timekey = [
+                        coord
+                        for coord in coords
+                        if ("time" in data[coord].attrs.values())
+                        or ("T" in data[coord].attrs.values())
+                    ]
                     if len(timekey) > 0:
                         timekey = timekey[0]
                         time_coverage_start = str(data[timekey].min().values)
                         time_coverage_end = str(data[timekey].max().values)
                     else:
-                        time_coverage_start = ''
-                        time_coverage_end = ''
-                    lonkey = [coord for coord in coords
-                                if ('lon' in data[coord].attrs.values())
-                                or ('X' in data[coord].attrs.values())]
+                        time_coverage_start = ""
+                        time_coverage_end = ""
+                    lonkey = [
+                        coord
+                        for coord in coords
+                        if ("lon" in data[coord].attrs.values())
+                        or ("X" in data[coord].attrs.values())
+                    ]
                     if len(lonkey) > 0:
                         lonkey = lonkey[0]
                         geospatial_lon_min = float(data[lonkey].min())
                         geospatial_lon_max = float(data[lonkey].max())
                     else:
-                        geospatial_lon_min = ''
-                        geospatial_lon_max = ''
-                    latkey = [coord for coord in coords
-                                if ('lat' in data[coord].attrs.values())
-                                or ('Y' in data[coord].attrs.values())]
+                        geospatial_lon_min = ""
+                        geospatial_lon_max = ""
+                    latkey = [
+                        coord
+                        for coord in coords
+                        if ("lat" in data[coord].attrs.values())
+                        or ("Y" in data[coord].attrs.values())
+                    ]
                     if len(latkey) > 0:
                         latkey = latkey[0]
                         geospatial_lat_min = float(data[latkey].min())
                         geospatial_lat_max = float(data[latkey].max())
                     else:
-                        geospatial_lat_min = ''
-                        geospatial_lat_max = ''
-                    metadata = {'coords': coords,
-                                'variables': list(data.data_vars.keys()),
-                                'time_variable': timekey,
-                                'lon_variable': lonkey,
-                                'lat_variable': latkey,
-                                'geospatial_lon_min': geospatial_lon_min,
-                                'geospatial_lon_max': geospatial_lon_max,
-                                'geospatial_lat_min': geospatial_lat_min,
-                                'geospatial_lat_max': geospatial_lat_max,
-                                'time_coverage_start': time_coverage_start,
-                                'time_coverage_end': time_coverage_end
-                                }
+                        geospatial_lat_min = ""
+                        geospatial_lat_max = ""
+                    metadata = {
+                        "coords": coords,
+                        "variables": list(data.data_vars.keys()),
+                        "time_variable": timekey,
+                        "lon_variable": lonkey,
+                        "lat_variable": latkey,
+                        "geospatial_lon_min": geospatial_lon_min,
+                        "geospatial_lon_max": geospatial_lon_max,
+                        "geospatial_lat_min": geospatial_lat_min,
+                        "geospatial_lat_max": geospatial_lat_max,
+                        "time_coverage_start": time_coverage_start,
+                        "time_coverage_end": time_coverage_end,
+                    }
                     file_intake.metadata = metadata
 
-                file_intake.name = filename.split('/')[-1]
-                lines += file_intake.yaml().strip('sources:')
+                file_intake.name = filename.split("/")[-1]
+                lines += file_intake.yaml().strip("sources:")
 
             f = open(self.catalog_name, "w")
             f.write(lines)
             f.close()
 
-
     @property
     def catalog(self):
 
-        if not hasattr(self, '_catalog'):
+        if not hasattr(self, "_catalog"):
 
             self.write_catalog()
             catalog = intake.open_catalog(self.catalog_name)
@@ -158,35 +153,31 @@ class LocalReader:
 
         return self._catalog
 
-
     @property
     def dataset_ids(self):
-        '''Find dataset_ids for server.'''
+        """Find dataset_ids for server."""
 
-        if not hasattr(self, '_dataset_ids'):
+        if not hasattr(self, "_dataset_ids"):
             self._dataset_ids = list(self.catalog)
 
         return self._dataset_ids
 
-
     def meta_by_dataset(self, dataset_id):
-        '''Should this return intake-style or a row of the metadata dataframe?'''
+        """Should this return intake-style or a row of the metadata dataframe?"""
 
         return self.catalog[dataset_id]
 
-
     @property
     def meta(self):
-        '''Rearrange the individual metadata into a dataframe.'''
+        """Rearrange the individual metadata into a dataframe."""
 
-        if not hasattr(self, '_meta'):
+        if not hasattr(self, "_meta"):
 
-            data = []
             if self.dataset_ids == []:
                 self._meta = None
             else:
                 # set up columns which might be different for datasets
-                columns = ['download_url']
+                columns = ["download_url"]
                 for dataset_id in self.dataset_ids:
                     meta = self.meta_by_dataset(dataset_id)
                     columns += list(meta.metadata.keys())
@@ -195,50 +186,52 @@ class LocalReader:
                 self._meta = pd.DataFrame(index=self.dataset_ids, columns=columns)
                 for dataset_id in self.dataset_ids:
                     meta = self.meta_by_dataset(dataset_id)
-                    self._meta.loc[dataset_id]['download_url'] = meta.urlpath
-                    self._meta.loc[dataset_id,list(meta.metadata.keys())] = list(meta.metadata.values())
+                    self._meta.loc[dataset_id]["download_url"] = meta.urlpath
+                    self._meta.loc[dataset_id, list(meta.metadata.keys())] = list(
+                        meta.metadata.values()
+                    )
                     # self._meta.loc[dataset_id][meta.metadata.keys()] = meta.metadata.values()
                     # data.append([meta.urlpath] + list(meta.metadata.values()))
                 # self._meta = pd.DataFrame(index=self.dataset_ids, columns=columns, data=data)
 
         return self._meta
 
-
     def data_by_dataset(self, dataset_id):
-        '''SHOULD I INCLUDE TIME RANGE?'''
+        """SHOULD I INCLUDE TIME RANGE?"""
 
         data = self.catalog[dataset_id].read()
-#         data = data.set_index('time')
-#         data = data[self.kw['min_time']:self.kw['max_time']]
+        #         data = data.set_index('time')
+        #         data = data[self.kw['min_time']:self.kw['max_time']]
 
         return (dataset_id, data)
-#         return (dataset_id, self.catalog[dataset_id].read())
 
+    #         return (dataset_id, self.catalog[dataset_id].read())
 
     # @property
     def data(self):
-        '''Do I need to worry about intake caching?
+        """Do I need to worry about intake caching?
 
         Data will be dataframes for csvs and
         Datasets for netcdf files.
-        '''
+        """
 
-        if not hasattr(self, '_data'):
+        if not hasattr(self, "_data"):
 
             if self.parallel:
                 num_cores = multiprocessing.cpu_count()
                 downloads = Parallel(n_jobs=num_cores)(
-                    delayed(self.data_by_dataset)(dataset_id) for dataset_id in self.dataset_ids
+                    delayed(self.data_by_dataset)(dataset_id)
+                    for dataset_id in self.dataset_ids
                 )
             else:
                 downloads = []
                 for dataset_id in self.dataset_ids:
                     downloads.append(self.data_by_dataset(dataset_id))
 
-#             if downloads is not None:
+            #             if downloads is not None:
             dds = {dataset_id: dd for (dataset_id, dd) in downloads}
-#             else:
-#                 dds = None
+            #             else:
+            #                 dds = None
 
             self._data = dds
 
@@ -246,21 +239,22 @@ class LocalReader:
 
 
 class region(LocalReader):
-#     def region(self, kw, variables=None):
-#         '''HOW TO INCORPORATE VARIABLE NAMES?'''
+    #     def region(self, kw, variables=None):
+    #         '''HOW TO INCORPORATE VARIABLE NAMES?'''
 
     def __init__(self, kwargs):
-        assert isinstance(kwargs, dict), 'input arguments as dictionary'
-        lo_kwargs = {'catalog_name': kwargs.get('catalog_name', None),
-                     'filenames': kwargs.get('filenames', None),
-                     'parallel': kwargs.get('parallel', True)}
+        assert isinstance(kwargs, dict), "input arguments as dictionary"
+        lo_kwargs = {
+            "catalog_name": kwargs.get("catalog_name", None),
+            "filenames": kwargs.get("filenames", None),
+            "parallel": kwargs.get("parallel", True),
+        }
         LocalReader.__init__(self, **lo_kwargs)
 
-        kw = kwargs['kw']
-        variables = kwargs.get('variables', None)
+        kw = kwargs["kw"]
+        variables = kwargs.get("variables", None)
 
-
-        self.approach = 'region'
+        self.approach = "region"
 
         self._stations = None
 
@@ -268,7 +262,7 @@ class region(LocalReader):
         # check for lon/lat values and time
         self.kw = kw
 
-# #         self.data_type = data_type
+        # #         self.data_type = data_type
         if (variables is not None) and (not isinstance(variables, list)):
             variables = [variables]
 
@@ -277,61 +271,60 @@ class region(LocalReader):
             self.check_variables(variables)
 
         self.variables = variables
+
+
 #         # DOESN'T CURRENTLY LIMIT WHICH VARIABLES WILL BE FOUND ON EACH SERVER
 
 #         return self
 
 
 class stations(LocalReader):
-#     def stations(self, dataset_ids=None, stations=None, kw=None):
-#         '''
-#         '''
-
+    #     def stations(self, dataset_ids=None, stations=None, kw=None):
+    #         '''
+    #         '''
 
     def __init__(self, kwargs):
-        assert isinstance(kwargs, dict), 'input arguments as dictionary'
-        loc_kwargs = {'catalog_name': kwargs.get('catalog_name', None),
-                     'filenames': kwargs.get('filenames', None),
-                     'parallel': kwargs.get('parallel', True)}
+        assert isinstance(kwargs, dict), "input arguments as dictionary"
+        loc_kwargs = {
+            "catalog_name": kwargs.get("catalog_name", None),
+            "filenames": kwargs.get("filenames", None),
+            "parallel": kwargs.get("parallel", True),
+        }
         LocalReader.__init__(self, **loc_kwargs)
 
-        kw = kwargs.get('kw', None)
-        dataset_ids = kwargs.get('dataset_ids', None)
-        stations = kwargs.get('stations', None)
+        kw = kwargs.get("kw", None)
+        self.approach = "stations"
 
-        self.approach = 'stations'
+        # #         self.catalog_name = os.path.join('..','catalogs',f'catalog_stations_{pd.Timestamp.now().isoformat()[:19]}.yml')
 
+        # #         # we want all the data associated with stations
+        # #         self.standard_names = None
 
+        #         # UPDATE SINCE NOW THERE IS A DIFFERENCE BETWEEN STATION AND DATASET
+        #         if dataset_ids is not None:
+        #             if not isinstance(dataset_ids, list):
+        #                 dataset_ids = [dataset_ids]
+        # #             self._stations = dataset_ids
+        #             self._dataset_ids = dataset_ids
 
-# #         self.catalog_name = os.path.join('..','catalogs',f'catalog_stations_{pd.Timestamp.now().isoformat()[:19]}.yml')
+        # #         assert (if dataset_ids is not None)
+        #         # assert that dataset_ids can't be something if axds_type is layer_group
+        #         # use stations instead, and don't use module uuid, use layer_group uuid
 
-# #         # we want all the data associated with stations
-# #         self.standard_names = None
+        #         if stations is not None:
+        #             if not isinstance(stations, list):
+        #                 stations = [stations]
+        #         self._stations = stations
 
-#         # UPDATE SINCE NOW THERE IS A DIFFERENCE BETWEEN STATION AND DATASET
-#         if dataset_ids is not None:
-#             if not isinstance(dataset_ids, list):
-#                 dataset_ids = [dataset_ids]
-# #             self._stations = dataset_ids
-#             self._dataset_ids = dataset_ids
-
-# #         assert (if dataset_ids is not None)
-#         # assert that dataset_ids can't be something if axds_type is layer_group
-#         # use stations instead, and don't use module uuid, use layer_group uuid
-
-#         if stations is not None:
-#             if not isinstance(stations, list):
-#                 stations = [stations]
-#         self._stations = stations
-
-#         self.dataset_ids
-
+        #         self.dataset_ids
 
         # CHECK FOR KW VALUES AS TIMES
         if kw is None:
-            kw = {'min_time': '1900-01-01', 'max_time': '2100-12-31'}
+            kw = {"min_time": "1900-01-01", "max_time": "2100-12-31"}
 
         self.kw = kw
+
+
 #         print(self.kwself.)
 
 

--- a/ocean_data_gateway/tests/test_axds.py
+++ b/ocean_data_gateway/tests/test_axds.py
@@ -1,119 +1,154 @@
 # from search.axdsReader import axdsReader
-import ocean_data_gateway as odg
-import pandas as pd
 import numpy as np
-from datetime import datetime
+import pandas as pd
 import xarray as xr
+
+import ocean_data_gateway as odg
 
 # CHECK PARALLEL AND NOT
 # CHECK CATALOG
 # TEST inputting catalog file
 
 
-## Test Platforms, stations ##
-
+# Test Platforms, stations
 def test_station_platforms_1dataset_id_alltime():
-    station = odg.axds.stations({'axds_type': 'platform2', 'dataset_ids': 'c61eecf1-1c0e-5287-b6fb-a92b51b14d54'})
-    assert station.kw == {'min_time': '1900-01-01', 'max_time': '2100-12-31'}
-    assert station.dataset_ids == ['c61eecf1-1c0e-5287-b6fb-a92b51b14d54']
+    station = odg.axds.stations(
+        {
+            "axds_type": "platform2",
+            "dataset_ids": "c61eecf1-1c0e-5287-b6fb-a92b51b14d54",
+        }
+    )
+    assert station.kw == {"min_time": "1900-01-01", "max_time": "2100-12-31"}
+    assert station.dataset_ids == ["c61eecf1-1c0e-5287-b6fb-a92b51b14d54"]
+
 
 def test_station_platforms_1dataset_id():
-    kw = {'min_time': '2020-8-1', 'max_time': '2020-8-2'}
-    dataset_ids = 'c61eecf1-1c0e-5287-b6fb-a92b51b14d54'
-    station = odg.axds.stations({'axds_type': 'platform2', 'dataset_ids': dataset_ids, 'kw': kw})
-    assert station.kw == {'min_time': '2020-8-1', 'max_time': '2020-8-2'}
+    kw = {"min_time": "2020-8-1", "max_time": "2020-8-2"}
+    dataset_ids = "c61eecf1-1c0e-5287-b6fb-a92b51b14d54"
+    station = odg.axds.stations(
+        {"axds_type": "platform2", "dataset_ids": dataset_ids, "kw": kw}
+    )
+    assert station.kw == {"min_time": "2020-8-1", "max_time": "2020-8-2"}
     assert station.dataset_ids == [dataset_ids]
     assert not station.meta.empty
     assert isinstance(station.meta, pd.DataFrame)
     data = station.data()
     assert isinstance(data[dataset_ids], pd.DataFrame)
-    assert (list(data[dataset_ids].index[[0,-1]].sort_values().values) ==
-                       [np.datetime64('2020-08-01T00:00:00.000000000'),
-                        np.datetime64('2020-08-02T23:50:21.000000000')])
+    assert list(data[dataset_ids].index[[0, -1]].sort_values().values) == [
+        np.datetime64("2020-08-01T00:00:00.000000000"),
+        np.datetime64("2020-08-02T23:50:21.000000000"),
+    ]
+
 
 def test_station_platforms_2dataset_ids():
-    kw = {'min_time': '2020-9-20', 'max_time': '2020-9-20'}
-    dataset_ids = ['c61eecf1-1c0e-5287-b6fb-a92b51b14d54',
-                   '7d4ea195-aeda-5c78-aa0d-d4f77ba0ad95']
-    stations = odg.axds.stations({'axds_type': 'platform2', 'dataset_ids': dataset_ids, 'kw': kw})
+    kw = {"min_time": "2020-9-20", "max_time": "2020-9-20"}
+    dataset_ids = [
+        "c61eecf1-1c0e-5287-b6fb-a92b51b14d54",
+        "7d4ea195-aeda-5c78-aa0d-d4f77ba0ad95",
+    ]
+    stations = odg.axds.stations(
+        {"axds_type": "platform2", "dataset_ids": dataset_ids, "kw": kw}
+    )
     assert stations.dataset_ids == dataset_ids
 
+
 def test_station_platforms_1station():
-    kw = {'min_time': '2020-8-1', 'max_time': '2020-8-2'}
-    stationname = 'ng645-20200730T1909'
-    dataset_id = 'c61eecf1-1c0e-5287-b6fb-a92b51b14d54'
-    stations = odg.axds.stations({'axds_type': 'platform2', 'stations': stationname, 'kw': kw})
+    kw = {"min_time": "2020-8-1", "max_time": "2020-8-2"}
+    stationname = "ng645-20200730T1909"
+    dataset_id = "c61eecf1-1c0e-5287-b6fb-a92b51b14d54"
+    stations = odg.axds.stations(
+        {"axds_type": "platform2", "stations": stationname, "kw": kw}
+    )
     assert stations.dataset_ids == [dataset_id]
 
 
-## Test layer_groups, stations ##
-
+# Test layer_groups, stations
 def test_station_layer_group_1station_alltime():
     # 1 SFBOFS layer_group
-    stations = ['04784baa-6be8-4aa7-b039-269f35e92e91']
+    stations = ["04784baa-6be8-4aa7-b039-269f35e92e91"]
     # SFBOFS module uuid
-    dataset_ids = ['03158b5d-f712-45f2-b05d-e4954372c1ce']
-    station = odg.axds.stations({'axds_type': 'layer_group', 'stations': stations[0]})
-    assert station.kw == {'min_time': '1900-01-01', 'max_time': '2100-12-31'}
+    dataset_ids = ["03158b5d-f712-45f2-b05d-e4954372c1ce"]
+    station = odg.axds.stations({"axds_type": "layer_group", "stations": stations[0]})
+    assert station.kw == {"min_time": "1900-01-01", "max_time": "2100-12-31"}
     assert station._stations == stations
     assert station.dataset_ids == dataset_ids
 
+
 def test_station_layer_group_1station():
-    kw = {'min_time': '2021-4-1', 'max_time': '2021-4-2'}
+    kw = {"min_time": "2021-4-1", "max_time": "2021-4-2"}
     # 1 SFBOFS layer_group
-    stations = ['04784baa-6be8-4aa7-b039-269f35e92e91']
+    stations = ["04784baa-6be8-4aa7-b039-269f35e92e91"]
     # SFBOFS module uuid
-    dataset_ids = ['03158b5d-f712-45f2-b05d-e4954372c1ce']
-    station = odg.axds.stations({'axds_type': 'layer_group', 'stations': stations, 'kw': kw})
+    dataset_ids = ["03158b5d-f712-45f2-b05d-e4954372c1ce"]
+    station = odg.axds.stations(
+        {"axds_type": "layer_group", "stations": stations, "kw": kw}
+    )
     assert station.kw == kw
     assert isinstance(station.meta, pd.DataFrame)
     assert not station.meta.empty
     data = station.data()
     assert isinstance(data[dataset_ids[0]], xr.Dataset)
-    assert (list(data[dataset_ids[0]].ocean_time[[0,-1]].values) ==
-                       [np.datetime64('2021-04-01T00:00:00.000000000'),
-                        np.datetime64('2021-04-02T23:00:00.000000000')])
+    assert list(data[dataset_ids[0]].ocean_time[[0, -1]].values) == [
+        np.datetime64("2021-04-01T00:00:00.000000000"),
+        np.datetime64("2021-04-02T23:00:00.000000000"),
+    ]
+
 
 def test_station_layer_group_2dataset_ids():
-    kw = {'min_time': '2021-4-1', 'max_time': '2021-4-2'}
+    kw = {"min_time": "2021-4-1", "max_time": "2021-4-2"}
     # 2 SFBOFS layer_groups
-    stations = ['04784baa-6be8-4aa7-b039-269f35e92e91',
-                   '29bd4c08-db9e-45ba-94ef-8ec34868d855']
+    stations = [
+        "04784baa-6be8-4aa7-b039-269f35e92e91",
+        "29bd4c08-db9e-45ba-94ef-8ec34868d855",
+    ]
     # SFBOFS module uuid
-    dataset_ids = ['03158b5d-f712-45f2-b05d-e4954372c1ce']
-    station = odg.axds.stations({'axds_type': 'layer_group', 'stations': stations, 'kw': kw})
+    dataset_ids = ["03158b5d-f712-45f2-b05d-e4954372c1ce"]
+    station = odg.axds.stations(
+        {"axds_type": "layer_group", "stations": stations, "kw": kw}
+    )
     assert station._stations == stations
     assert station.dataset_ids == dataset_ids
 
 
-## Test variables search and check ##
-
+# Test variables search and check
 def test_variables():
     pass
 
 
-## Test Platforms, region ##
-
+# Test Platforms, region
 def test_region_platforms_no_variables():
-    kw = {'min_time': '2015-1-1', 'max_time': '2015-1-2',
-         'min_lon': -98, 'max_lon': -97.5, 'min_lat': 28.5, 'max_lat': 29}
-    dataset_ids = ['1b046f4e-5dd6-5ba7-8d70-743e2edeb1df',
-                   '7d196e00-4d79-5d4a-a978-f56161d758ce']
-    region = odg.axds.region({'kw': kw})
+    kw = {
+        "min_time": "2015-1-1",
+        "max_time": "2015-1-2",
+        "min_lon": -98,
+        "max_lon": -97.5,
+        "min_lat": 28.5,
+        "max_lat": 29,
+    }
+    dataset_ids = [
+        "1b046f4e-5dd6-5ba7-8d70-743e2edeb1df",
+        "7d196e00-4d79-5d4a-a978-f56161d758ce",
+    ]
+    region = odg.axds.region({"kw": kw})
     assert sorted(region.dataset_ids) == dataset_ids
     assert region.kw == kw
 
+
 def test_region_platforms_variables():
-    kw = {'min_time': '2019-1-1', 'max_time': '2021-1-2',
-         'min_lon': -98, 'max_lon': -95, 'min_lat': 28, 'max_lat': 29}
-    dataset_ids = ['612c17e4-3306-5d51-abb2-7e890fe49896']
-    variables = ['Salinity']
-    region = odg.axds.region({'kw': kw, 'variables': variables})
+    kw = {
+        "min_time": "2019-1-1",
+        "max_time": "2021-1-2",
+        "min_lon": -98,
+        "max_lon": -95,
+        "min_lat": 28,
+        "max_lat": 29,
+    }
+    dataset_ids = ["612c17e4-3306-5d51-abb2-7e890fe49896"]
+    variables = ["Salinity"]
+    region = odg.axds.region({"kw": kw, "variables": variables})
     assert dataset_ids[0] in region.dataset_ids
     assert region.kw == kw
     assert region.variables == variables
 
 
-
-
-## Test layer_groups, region ##
+# Test layer_groups, region

--- a/ocean_data_gateway/tests/test_erddap.py
+++ b/ocean_data_gateway/tests/test_erddap.py
@@ -1,72 +1,98 @@
-# from search.ErddapReader import ErddapReader
-import ocean_data_gateway as odg
-import pandas as pd
 import numpy as np
-from datetime import datetime
-import xarray as xr
+import pandas as pd
+
+import ocean_data_gateway as odg
 
 
 def test_station_ioos_1dataset_id_alltime():
-    station = odg.erddap.stations({'dataset_ids': 'noaa_nos_co_ops_8771013'})
-    assert station.kw == {'min_time': '1900-01-01', 'max_time': '2100-12-31'}
-    assert station.dataset_ids == ['noaa_nos_co_ops_8771013']
+    station = odg.erddap.stations({"dataset_ids": "noaa_nos_co_ops_8771013"})
+    assert station.kw == {"min_time": "1900-01-01", "max_time": "2100-12-31"}
+    assert station.dataset_ids == ["noaa_nos_co_ops_8771013"]
+
 
 def test_station_ioos_1dataset_id():
-    kw = {'min_time': '2019-1-1', 'max_time': '2019-1-2'}
-    station = odg.erddap.stations({'dataset_ids': 'noaa_nos_co_ops_8771013', 'kw': kw})
-    assert station.kw == {'min_time': '2019-1-1', 'max_time': '2019-1-2'}
+    kw = {"min_time": "2019-1-1", "max_time": "2019-1-2"}
+    station = odg.erddap.stations({"dataset_ids": "noaa_nos_co_ops_8771013", "kw": kw})
+    assert station.kw == {"min_time": "2019-1-1", "max_time": "2019-1-2"}
     assert isinstance(station.meta, pd.DataFrame)
     data = station.data()
-    assert isinstance(data['noaa_nos_co_ops_8771013'], pd.DataFrame)
-    assert (list(data['noaa_nos_co_ops_8771013'].index[[0,-1]].sort_values().values) ==
-                       [np.datetime64('2019-01-01T00:00:00.000000000'),
-                        np.datetime64('2019-01-02T00:00:00.000000000')])
+    assert isinstance(data["noaa_nos_co_ops_8771013"], pd.DataFrame)
+    assert list(
+        data["noaa_nos_co_ops_8771013"].index[[0, -1]].sort_values().values
+    ) == [
+        np.datetime64("2019-01-01T00:00:00.000000000"),
+        np.datetime64("2019-01-02T00:00:00.000000000"),
+    ]
+
 
 def test_station_ioos_2dataset_ids():
-    kw = {'min_time': '2019-1-1', 'max_time': '2019-1-2'}
-    dataset_ids = ['noaa_nos_co_ops_8771013', 'noaa_nos_co_ops_8774230']
-    stations = odg.erddap.stations({'dataset_ids': dataset_ids, 'kw': kw})
+    kw = {"min_time": "2019-1-1", "max_time": "2019-1-2"}
+    dataset_ids = ["noaa_nos_co_ops_8771013", "noaa_nos_co_ops_8774230"]
+    stations = odg.erddap.stations({"dataset_ids": dataset_ids, "kw": kw})
     assert stations.dataset_ids == dataset_ids
     assert not stations.meta.empty
-    data = stations.data()
+
 
 def test_station_ioos_1station():
-    kw = {'min_time': '2019-1-1', 'max_time': '2019-1-2'}
-    stationname = '8771013'
-    stations = odg.erddap.stations({'stations': stationname, 'kw': kw})
-    assert stations.dataset_ids == ['noaa_nos_co_ops_8771013']
+    kw = {"min_time": "2019-1-1", "max_time": "2019-1-2"}
+    stationname = "8771013"
+    stations = odg.erddap.stations({"stations": stationname, "kw": kw})
+    assert stations.dataset_ids == ["noaa_nos_co_ops_8771013"]
     assert not stations.meta.empty
 
+
 def test_station_ioos_2stations():
-    kw = {'min_time': '2019-1-1', 'max_time': '2019-1-2'}
-    dataset_ids = ['noaa_nos_co_ops_8771013', 'noaa_nos_co_ops_8774230']
-    stationnames = ['8771013', '8774230']
-    stations = odg.erddap.stations({'stations': stationnames, 'kw': kw})
+    kw = {"min_time": "2019-1-1", "max_time": "2019-1-2"}
+    dataset_ids = ["noaa_nos_co_ops_8771013", "noaa_nos_co_ops_8774230"]
+    stationnames = ["8771013", "8774230"]
+    stations = odg.erddap.stations({"stations": stationnames, "kw": kw})
     assert sorted(stations.dataset_ids) == dataset_ids
     assert not stations.meta.empty
 
+
 def test_region_coastwatch():
-    kw = {'min_time': '2019-1-1', 'max_time': '2019-1-2',
-         'min_lon': -99, 'max_lon': -88, 'min_lat': 20, 'max_lat': 30}
-    variables = ['water_u', 'water_v']
-    region = odg.erddap.region({'kw': kw, 'variables': variables,
-                                'known_server': 'coastwatch'})
-    assert 'ucsdHfrE1' in region.dataset_ids
+    kw = {
+        "min_time": "2019-1-1",
+        "max_time": "2019-1-2",
+        "min_lon": -99,
+        "max_lon": -88,
+        "min_lat": 20,
+        "max_lat": 30,
+    }
+    variables = ["water_u", "water_v"]
+    region = odg.erddap.region(
+        {"kw": kw, "variables": variables, "known_server": "coastwatch"}
+    )
+    assert "ucsdHfrE1" in region.dataset_ids
     # assert sorted(region.dataset_ids) == ['ucsdHfrE1', 'ucsdHfrE2', 'ucsdHfrE6']
     assert not region.meta.empty
 
+
 def test_station_coastwatch():
-    kw = {'min_time': '2019-1-1', 'max_time': '2019-1-2'}
-    dataset_id = 'ucsdHfrE6'
-    station = odg.erddap.stations({'dataset_ids': dataset_id, 'kw': kw,
-                                    'parallel': False, 'known_server': 'coastwatch'})
+    kw = {"min_time": "2019-1-1", "max_time": "2019-1-2"}
+    dataset_id = "ucsdHfrE6"
+    station = odg.erddap.stations(
+        {
+            "dataset_ids": dataset_id,
+            "kw": kw,
+            "parallel": False,
+            "known_server": "coastwatch",
+        }
+    )
     assert station.kw == kw
     assert isinstance(station.meta, pd.DataFrame)
 
+
 def test_region_ioos():
-    kw = {'min_time': '2019-1-1', 'max_time': '2019-1-2',
-         'min_lon': -95, 'max_lon': -94, 'min_lat': 27, 'max_lat': 29}
-    variables = ['sea_water_practical_salinity']
-    region = odg.erddap.region({'kw': kw, 'variables': variables})
-    assert 'tabs_b' in region.dataset_ids
+    kw = {
+        "min_time": "2019-1-1",
+        "max_time": "2019-1-2",
+        "min_lon": -95,
+        "max_lon": -94,
+        "min_lat": 27,
+        "max_lat": 29,
+    }
+    variables = ["sea_water_practical_salinity"]
+    region = odg.erddap.region({"kw": kw, "variables": variables})
+    assert "tabs_b" in region.dataset_ids
     assert not region.meta.empty


### PR DESCRIPTION
Changes motivated to test installation and enable usage of the package.

Specifically:
- Changes to imports to prevent circular dependencies.
- Logging initialized in package `__init__.py` with module loggers inheriting from that root logger.
- Apply flake8 ignoring E501.  Remaining issues with W503, E266, E722, W606, and F541.
- Apply black for formatting.
- Apply isort for formatting imports.
- Add environment.yml for package dependencies.