### PR TITLE
fix for imports and make readers a real module

### DIFF
--- a/ocean_data_gateway/__init__.py
+++ b/ocean_data_gateway/__init__.py
@@ -6,6 +6,7 @@ try:
 except ImportError:
     __version__ = "unknown"
 
+from .readers import axds, erddap, local
 
 base_path = Path.home() / ".ocean_data_gateway"
 base_path.mkdir(exist_ok=True)


### PR DESCRIPTION
Fix for tests failing.

- Add import for readers in ocean_data_gateway __init__
- Make readers a real module