### PR TITLE
[OSRA-118] Refactor

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Run Tests
         shell: bash -l {0}
         run: |
-          pytest --cov=./ --cov-report=xml
+          pytest --cov=./ --cov-report=xml --integration
       - name: Upload code coverage to Codecov
         uses: codecov/codecov-action@v1
         with:

--- a/ocean_data_gateway/__init__.py
+++ b/ocean_data_gateway/__init__.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 from .utils import (  # isort:skip  # noqa: E402, F401
     resample_like,
+    fetch_criteria,
 )
 
 

--- a/ocean_data_gateway/__init__.py
+++ b/ocean_data_gateway/__init__.py
@@ -14,8 +14,6 @@ from pathlib import Path
 
 
 from .utils import (  # isort:skip  # noqa: E402, F401
-    Reader,
-    load_data,
     resample_like,
 )
 
@@ -73,12 +71,6 @@ logging.captureWarnings(True)
 
 # all available sources/readers
 _SOURCES = [erddap, axds, local]
-
-# important built-in options for readers
-OPTIONS = {
-    "erddap": {"known_server": ["ioos", "coastwatch"]},
-    "axds": {"axds_type": ["platform2", "layer_group"]},
-}
 
 # Available keys for Gateway
 keys_kwargs = [

--- a/ocean_data_gateway/gateway.py
+++ b/ocean_data_gateway/gateway.py
@@ -9,12 +9,15 @@ import cf_xarray
 import pandas as pd
 import pint_xarray
 import xarray as xr
+
 from cf_xarray.units import units
 from ioos_qc.config import QcConfig
 
 import ocean_data_gateway as odg
+
 from ocean_data_gateway import utils
 from ocean_data_gateway.readers import DataReader, Reader
+
 
 pint_xarray.unit_registry = units
 
@@ -33,6 +36,7 @@ class Gateway(Reader):
     kwargs: dict
         Keyword arguments that contain specific arguments for the readers.
     """
+
     reader_default_options = {
         "erddap": {"known_server": ["ioos", "coastwatch"]},
         "axds": {"axds_type": ["platform2", "layer_group"]},
@@ -214,7 +218,9 @@ class Gateway(Reader):
             reader_values = [reader_values]
         return reader_key, reader_values
 
-    def _sanitize_variables(self, source: ModuleType, reader_values: List[Any]) -> List[Any]:
+    def _sanitize_variables(
+        self, source: ModuleType, reader_values: List[Any]
+    ) -> List[Any]:
         """Return a list of sanitized variables. Returns a list of None if no variables specified."""
         # catch if the user is putting in a set of variables to match
         # the set of reader options
@@ -228,14 +234,14 @@ class Gateway(Reader):
         #                         variables_values
         # catch scenario where variables input to all readers at once
         elif "variables" in self.kwargs_all:
-            variables_values = [self.kwargs_all["variables"]] * len(
-                reader_values
-            )
+            variables_values = [self.kwargs_all["variables"]] * len(reader_values)
         else:
             variables_values = [None] * len(reader_values)
         return variables_values
 
-    def _initialize_reader(self, source: ModuleType, option: Any, reader_key: str, variables: List[str]) -> DataReader:
+    def _initialize_reader(
+        self, source: ModuleType, option: Any, reader_key: str, variables: List[str]
+    ) -> DataReader:
         """Return the initialized reader using appropriate args."""
         # setup reader with kwargs for that reader
         # prioritize input kwargs over default args
@@ -273,10 +279,10 @@ class Gateway(Reader):
                 reader_key, reader_values = self._find_reader(source)
                 variables_values = self._sanitize_variables(source, reader_values)
 
-                for option, variables in zip(
-                    reader_values, variables_values
-                ):
-                    reader = self._initialize_reader(source, option, reader_key, variables)
+                for option, variables in zip(reader_values, variables_values):
+                    reader = self._initialize_reader(
+                        source, option, reader_key, variables
+                    )
                     sources.append(reader)
 
             self._sources = sources

--- a/ocean_data_gateway/readers/__init__.py
+++ b/ocean_data_gateway/readers/__init__.py
@@ -3,10 +3,11 @@
 """
 Readers available for ocean_data_gateway.
 """
-from .reader import Reader
+from .axds import AxdsReader
 from .data_reader import DataReader
 from .erddap import ErddapReader
-from .axds import AxdsReader
 from .local import LocalReader
+from .reader import Reader
+
 
 __all__ = ["Reader", "DataReader", "ErddapReader", "AxdsReader", "LocalReader"]

--- a/ocean_data_gateway/readers/__init__.py
+++ b/ocean_data_gateway/readers/__init__.py
@@ -1,3 +1,12 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
 Readers available for ocean_data_gateway.
 """
+from .reader import Reader
+from .data_reader import DataReader
+from .erddap import ErddapReader
+from .axds import AxdsReader
+from .local import LocalReader
+
+__all__ = ["Reader", "DataReader", "ErddapReader", "AxdsReader", "LocalReader"]

--- a/ocean_data_gateway/readers/axds.py
+++ b/ocean_data_gateway/readers/axds.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
 Reader for Axiom databases.
 """
@@ -15,9 +17,8 @@ import requests
 import xarray as xr
 
 import ocean_data_gateway as odg
-
-from ocean_data_gateway import Reader, utils
-
+from ocean_data_gateway import utils
+from ocean_data_gateway.readers import DataReader
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +27,7 @@ logger = logging.getLogger(__name__)
 reader = "axds"
 
 
-class AxdsReader(Reader):
+class AxdsReader(DataReader):
     """
     This class searches Axiom databases for types `platforms2`, which
     are like gliders, and `layer_group`, which are like grids and models.
@@ -55,6 +56,8 @@ class AxdsReader(Reader):
     reader: string
         Reader name: AxdsReader
     """
+    default_options = {"axds_type": ["platform2", "layer_group"]}
+    source_name = 'axds'
 
     def __init__(
         self, parallel=True, catalog_name=None, axds_type="platform2", filetype="netcdf"
@@ -207,17 +210,17 @@ class AxdsReader(Reader):
         to access the time limits of the search.
         """
         # convert input datetime to seconds since 1970
-        startDateTime = (
+        start_date_time = (
             pd.Timestamp(self.kw["min_time"]).tz_localize("UTC")
             - pd.Timestamp("1970-01-01 00:00").tz_localize("UTC")
         ) // pd.Timedelta("1s")
-        endDateTime = (
+        end_date_time = (
             pd.Timestamp(self.kw["max_time"]).tz_localize("UTC")
             - pd.Timestamp("1970-01-01 00:00").tz_localize("UTC")
         ) // pd.Timedelta("1s")
 
         # search by time
-        url_add_time = f"&startDateTime={startDateTime}&endDateTime={endDateTime}"
+        url_add_time = f"&startDateTime={start_date_time}&endDateTime={end_date_time}"
 
         return f"{url_add_time}"
 
@@ -755,20 +758,6 @@ sources:
 
         # return (dataset_id, data)
         return data
-
-    # @property
-    def data(self, dataset_ids=None):
-        """Read in data for some or all dataset_ids.
-
-        NOT USED CURRENTLY
-
-        Once data is read in for a dataset_ids, it is remembered.
-
-        See full documentation in `utils.load_data()`.
-        """
-
-        output = odg.utils.load_data(self, dataset_ids)
-        return output
 
     def save(self):
         """Save datasets locally."""

--- a/ocean_data_gateway/readers/axds.py
+++ b/ocean_data_gateway/readers/axds.py
@@ -17,8 +17,10 @@ import requests
 import xarray as xr
 
 import ocean_data_gateway as odg
+
 from ocean_data_gateway import utils
 from ocean_data_gateway.readers import DataReader
+
 
 logger = logging.getLogger(__name__)
 
@@ -56,8 +58,9 @@ class AxdsReader(DataReader):
     reader: string
         Reader name: AxdsReader
     """
+
     default_options = {"axds_type": ["platform2", "layer_group"]}
-    source_name = 'axds'
+    source_name = "axds"
 
     def __init__(
         self, parallel=True, catalog_name=None, axds_type="platform2", filetype="netcdf"

--- a/ocean_data_gateway/readers/axds.py
+++ b/ocean_data_gateway/readers/axds.py
@@ -19,7 +19,7 @@ import xarray as xr
 import ocean_data_gateway as odg
 
 from ocean_data_gateway import utils
-from ocean_data_gateway.readers import DataReader
+from ocean_data_gateway.readers.data_reader import DataReader
 
 
 logger = logging.getLogger(__name__)

--- a/ocean_data_gateway/readers/data_reader.py
+++ b/ocean_data_gateway/readers/data_reader.py
@@ -5,7 +5,7 @@ import multiprocessing
 
 import joblib
 
-from ocean_data_gateway.readers import Reader
+from ocean_data_gateway.readers.reader import Reader
 
 
 class DataReader(Reader):

--- a/ocean_data_gateway/readers/data_reader.py
+++ b/ocean_data_gateway/readers/data_reader.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Abstract base class for a reader capable of loading data"""
+import multiprocessing
+
+from ocean_data_gateway.readers import Reader
+
+
+class DataReader(Reader):
+    """Abstract base class for a reader capable of loading data."""
+
+    def data(self, dataset_ids=None):
+        return self.load_data(dataset_ids)
+
+    def data_by_dataset(self, dataset_ids=None):
+        """Abstract method"""
+        raise NotImplementedError("method data_by_dataset is not implemented in abstract base class.")
+
+    def load_data(self, dataset_ids=None):
+        """Read in data for readers some or all dataset_ids.
+
+        Once data is read in for a dataset_ids, it is remembered. This is used in
+        all of the readers.
+
+        Parameters
+        ----------
+        dataset_ids: string, list, optional
+            Read in data for dataset_ids specifically, or return a look at the
+            currently available data. Options are:
+            * a string of 1 dataset_id
+            * a list of strings of dataset_ids
+            * None or nothing entered: data will be read in for all
+            `self.dataset_ids`.
+            * 'printkeys' will return a dictionary of the dataset_ids already read
+            in
+            * 'printall' will return all the data available
+
+        Returns
+        -------
+        There is different behavior for different inputs. If `dataset_ids` is a string, the Dataset for that dataset_id will be returned. If `dataset_ids` is a list of dataset_ids or `dataset_ids==None`, a dictionary will be returned with keys of the dataset_ids and values the data of type pandas DataFrame. Or use the strings 'printkeys' or 'printall' for a look at the data presently available.
+
+        Notes
+        -----
+        This is either done in parallel with the `multiprocessing` library or
+        in serial.
+        """
+
+        # first time called, set up self._data as a dict
+        if not hasattr(self, "_data"):
+            self._data = {}
+
+        if dataset_ids == "printkeys":
+            return self._data.keys()
+
+        elif dataset_ids == "printall":
+            return self._data
+
+        # for a single dataset_ids, just return that Dataset
+        elif (dataset_ids is not None) and (isinstance(dataset_ids, str)):
+
+            assertion = "dataset_id is not valid for this search"
+            assert dataset_ids in self.dataset_ids, assertion
+
+            if dataset_ids not in self._data:
+                self._data[dataset_ids] = self.data_by_dataset(dataset_ids)
+            return self._data[dataset_ids]
+
+        # Read in data for user-input dataset_ids or all dataset_ids
+        elif (dataset_ids is None) or (
+            (dataset_ids is not None) and (isinstance(dataset_ids, list))
+        ):
+
+            if dataset_ids is None:
+                dataset_ids_to_use = self.dataset_ids
+            else:
+                dataset_ids_to_use = dataset_ids
+
+            # first find which dataset_ids_to_use haven't already been read in
+            dataset_ids_to_use = [
+                dataid for dataid in dataset_ids_to_use if dataid not in self._data
+            ]
+
+            if self.parallel:
+                num_cores = multiprocessing.cpu_count()
+                downloads = Parallel(n_jobs=num_cores)(
+                    delayed(self.data_by_dataset)(dataid) for dataid in dataset_ids_to_use
+                )
+                for dataid, download in zip(dataset_ids_to_use, downloads):
+                    self._data[dataid] = download
+
+            else:
+                for dataid in dataset_ids_to_use:
+                    self._data[dataid] = self.data_by_dataset(dataid)
+
+        return self._data

--- a/ocean_data_gateway/readers/data_reader.py
+++ b/ocean_data_gateway/readers/data_reader.py
@@ -3,20 +3,25 @@
 """Abstract base class for a reader capable of loading data"""
 import multiprocessing
 
+import joblib
+
 from ocean_data_gateway.readers import Reader
 
 
 class DataReader(Reader):
     """Abstract base class for a reader capable of loading data."""
 
-    def data(self, dataset_ids=None):
+    def data(self, dataset_ids=None) -> dict:
+        """Loads data for the given dataset IDs."""
         return self.load_data(dataset_ids)
 
     def data_by_dataset(self, dataset_ids=None):
         """Abstract method"""
-        raise NotImplementedError("method data_by_dataset is not implemented in abstract base class.")
+        raise NotImplementedError(
+            "method data_by_dataset is not implemented in abstract base class."
+        )
 
-    def load_data(self, dataset_ids=None):
+    def load_data(self, dataset_ids=None) -> dict:
         """Read in data for readers some or all dataset_ids.
 
         Once data is read in for a dataset_ids, it is remembered. This is used in
@@ -82,8 +87,9 @@ class DataReader(Reader):
 
             if self.parallel:
                 num_cores = multiprocessing.cpu_count()
-                downloads = Parallel(n_jobs=num_cores)(
-                    delayed(self.data_by_dataset)(dataid) for dataid in dataset_ids_to_use
+                downloads = joblib.Parallel(n_jobs=num_cores)(
+                    joblib.delayed(self.data_by_dataset)(dataid)
+                    for dataid in dataset_ids_to_use
                 )
                 for dataid, download in zip(dataset_ids_to_use, downloads):
                     self._data[dataid] = download

--- a/ocean_data_gateway/readers/erddap.py
+++ b/ocean_data_gateway/readers/erddap.py
@@ -18,7 +18,7 @@ from joblib import Parallel, delayed
 import ocean_data_gateway as odg
 
 from ocean_data_gateway import utils
-from ocean_data_gateway.readers import DataReader
+from ocean_data_gateway.readers.data_reader import DataReader
 
 
 logger = logging.getLogger(__name__)

--- a/ocean_data_gateway/readers/erddap.py
+++ b/ocean_data_gateway/readers/erddap.py
@@ -4,18 +4,22 @@ Reader for ERDDAP servers.
 
 import logging
 import multiprocessing
-from typing import Optional
 import urllib.parse
+
+from typing import Optional
 
 import cf_xarray  # noqa: F401
 import pandas as pd
 import xarray as xr
+
 from erddapy import ERDDAP
 from joblib import Parallel, delayed
 
 import ocean_data_gateway as odg
+
 from ocean_data_gateway import utils
 from ocean_data_gateway.readers import DataReader
+
 
 logger = logging.getLogger(__name__)
 
@@ -51,10 +55,18 @@ class ErddapReader(DataReader):
     reader: string
         reader is defined as "ErddapReader".
     """
-    default_options = {"known_server": ["ioos", "coastwatch"]}
-    source_name = 'erddap'
 
-    def __init__(self, known_server="ioos", protocol=None, server=None, parallel=False, erddap_client_class: Optional[type] = None):
+    default_options = {"known_server": ["ioos", "coastwatch"]}
+    source_name = "erddap"
+
+    def __init__(
+        self,
+        known_server="ioos",
+        protocol=None,
+        server=None,
+        parallel=False,
+        erddap_client_class: Optional[type] = None,
+    ):
         """
         Parameters
         ----------

--- a/ocean_data_gateway/readers/local.py
+++ b/ocean_data_gateway/readers/local.py
@@ -12,7 +12,7 @@ import pandas as pd
 
 import ocean_data_gateway as odg
 
-from ocean_data_gateway.readers import DataReader
+from ocean_data_gateway.readers.data_reader import DataReader
 
 
 logger = logging.getLogger(__name__)

--- a/ocean_data_gateway/readers/local.py
+++ b/ocean_data_gateway/readers/local.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 # search.LocalReader.reader
 reader = "local"
 
+
 class LocalReader(DataReader):
     """
     This class searches local files.
@@ -45,8 +46,8 @@ class LocalReader(DataReader):
     TO DO: Can this reader be used for remote datasets but for
     which we know the specific file location?
     """
-    source_name = 'local'
 
+    source_name = "local"
 
     def __init__(self, parallel=True, catalog_name=None, filenames=None, kw=None):
         """

--- a/ocean_data_gateway/readers/local.py
+++ b/ocean_data_gateway/readers/local.py
@@ -12,7 +12,7 @@ import pandas as pd
 
 import ocean_data_gateway as odg
 
-from ocean_data_gateway import Reader
+from ocean_data_gateway.readers import DataReader
 
 
 logger = logging.getLogger(__name__)
@@ -21,8 +21,7 @@ logger = logging.getLogger(__name__)
 # search.LocalReader.reader
 reader = "local"
 
-
-class LocalReader(Reader):
+class LocalReader(DataReader):
     """
     This class searches local files.
 
@@ -46,6 +45,8 @@ class LocalReader(Reader):
     TO DO: Can this reader be used for remote datasets but for
     which we know the specific file location?
     """
+    source_name = 'local'
+
 
     def __init__(self, parallel=True, catalog_name=None, filenames=None, kw=None):
         """
@@ -256,9 +257,6 @@ class LocalReader(Reader):
                     self._meta.loc[dataset_id, list(meta.metadata.keys())] = list(
                         meta.metadata.values()
                     )
-                    # self._meta.loc[dataset_id][meta.metadata.keys()] = meta.metadata.values()
-                    # data.append([meta.urlpath] + list(meta.metadata.values()))
-                # self._meta = pd.DataFrame(index=self.dataset_ids, columns=columns, data=data)
 
         return self._meta
 
@@ -280,23 +278,6 @@ class LocalReader(Reader):
         #         data = data.set_index('time')
         #         data = data[self.kw['min_time']:self.kw['max_time']]
         return data
-        # return (dataset_id, data)
-
-    #         return (dataset_id, self.catalog[dataset_id].read())
-
-    # @property
-    def data(self, dataset_ids=None):
-        """Read in data for some or all dataset_ids.
-
-        NOT USED CURRENTLY
-
-        Once data is read in for a dataset_ids, it is remembered.
-
-        See full documentation in `utils.load_data()`.
-        """
-
-        output = odg.utils.load_data(self, dataset_ids)
-        return output
 
 
 class region(LocalReader):

--- a/ocean_data_gateway/readers/reader.py
+++ b/ocean_data_gateway/readers/reader.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+"""Reader baseclass definition."""
 from collections.abc import MutableMapping
 
 

--- a/ocean_data_gateway/readers/reader.py
+++ b/ocean_data_gateway/readers/reader.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from collections.abc import MutableMapping
+
+
+# dict-like structure for readers to inherit
+class Reader(MutableMapping):
+    """dict-like reader class.
+
+    This is the base class for all of the readers so they can have methods and
+    can also store and access data in a dict-like manner for convenience, which
+    simplifies the syntax a lot.
+    """
+
+    def __init__(self):
+        """Initialize a reader class."""
+        self.store = dict()
+        # self.update(dict(*args, **kwargs))  # use the free update to set keys
+
+    def __getitem__(self, key):
+        """This method is overwritten by the readers."""
+        # this is overwritten by the same method in each reader
+        return key
+
+    def __setitem__(self, key, value):
+        """Regular dict-like way to store key/value pair."""
+        self.store[key] = value
+
+    def __delitem__(self, key):
+        """Regular dict-like way to delete key."""
+        del self.store[key]
+
+    def __iter__(self):
+        """Regular dict-like way to iter over object."""
+        return iter(self.store)
+
+    def __len__(self):
+        """Regular dict-like way query length of object."""
+        return len(self.store)
+
+    def keys(self):
+        """Regular dict-like way to return keys."""
+        return self.store.keys()
+
+    def values(self):
+        """Regular dict-like way to return values."""
+        return self.store.values()

--- a/ocean_data_gateway/utils.py
+++ b/ocean_data_gateway/utils.py
@@ -47,3 +47,10 @@ def fetch_criteria(url: str) -> dict:
     response = requests.get(url)
     response.raise_for_status()
     return response.json()
+
+
+def return_response(url: str):
+    """Deprecated"""
+    raise DeprecationWarning(
+        "return_response is deprecated. use fetch_criteria instead"
+    )

--- a/ocean_data_gateway/utils.py
+++ b/ocean_data_gateway/utils.py
@@ -1,18 +1,11 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
 Utilities to help with running the other code.
-
-match_var()
 """
-
-import multiprocessing
-
-# https://stackoverflow.com/questions/3387691/how-to-perfectly-override-a-dict
-from collections.abc import MutableMapping
 
 import pandas as pd
 import requests
-
-from joblib import Parallel, delayed
 
 
 def resample_like(ds_resample, ds_resample_to):
@@ -46,131 +39,6 @@ def resample_like(ds_resample, ds_resample_to):
     return ds_resampled
 
 
-def load_data(self, dataset_ids=None):
-    """Read in data for readers some or all dataset_ids.
-
-    NOT USED CURRENTLY
-
-    Once data is read in for a dataset_ids, it is remembered. This is used in
-    all of the readers.
-
-    Parameters
-    ----------
-    dataset_ids: string, list, optional
-        Read in data for dataset_ids specifically, or return a look at the
-        currently available data. Options are:
-        * a string of 1 dataset_id
-        * a list of strings of dataset_ids
-        * None or nothing entered: data will be read in for all
-          `self.dataset_ids`.
-        * 'printkeys' will return a dictionary of the dataset_ids already read
-          in
-        * 'printall' will return all the data available
-
-    Returns
-    -------
-    There is different behavior for different inputs. If `dataset_ids` is a string, the Dataset for that dataset_id will be returned. If `dataset_ids` is a list of dataset_ids or `dataset_ids==None`, a dictionary will be returned with keys of the dataset_ids and values the data of type pandas DataFrame. Or use the strings 'printkeys' or 'printall' for a look at the data presently available.
-
-    Notes
-    -----
-    This is either done in parallel with the `multiprocessing` library or
-    in serial.
-    """
-
-    # first time called, set up self._data as a dict
-    if not hasattr(self, "_data"):
-        self._data = {}
-
-    if dataset_ids == "printkeys":
-        return self._data.keys()
-
-    elif dataset_ids == "printall":
-        return self._data
-
-    # for a single dataset_ids, just return that Dataset
-    elif (dataset_ids is not None) and (isinstance(dataset_ids, str)):
-
-        assertion = "dataset_id is not valid for this search"
-        assert dataset_ids in self.dataset_ids, assertion
-
-        if dataset_ids not in self._data:
-            self._data[dataset_ids] = self.data_by_dataset(dataset_ids)
-        return self._data[dataset_ids]
-
-    # Read in data for user-input dataset_ids or all dataset_ids
-    elif (dataset_ids is None) or (
-        (dataset_ids is not None) and (isinstance(dataset_ids, list))
-    ):
-
-        if dataset_ids is None:
-            dataset_ids_to_use = self.dataset_ids
-        else:
-            dataset_ids_to_use = dataset_ids
-
-        # first find which dataset_ids_to_use haven't already been read in
-        dataset_ids_to_use = [
-            dataid for dataid in dataset_ids_to_use if dataid not in self._data
-        ]
-
-        if self.parallel:
-            num_cores = multiprocessing.cpu_count()
-            downloads = Parallel(n_jobs=num_cores)(
-                delayed(self.data_by_dataset)(dataid) for dataid in dataset_ids_to_use
-            )
-            for dataid, download in zip(dataset_ids_to_use, downloads):
-                self._data[dataid] = download
-
-        else:
-            for dataid in dataset_ids_to_use:
-                self._data[dataid] = self.data_by_dataset(dataid)
-
-    return self._data
-
-
-# dict-like structure for readers to inherit
-class Reader(MutableMapping):
-    """dict-like reader class.
-
-    This is the base class for all of the readers so they can have methods and
-    can also store and access data in a dict-like manner for convenience, which
-    simplifies the syntax a lot.
-    """
-
-    def __init__(self):
-        """Initialize a reader class."""
-        self.store = dict()
-        # self.update(dict(*args, **kwargs))  # use the free update to set keys
-
-    def __getitem__(self, key):
-        """This method is overwritten by the readers."""
-        # this is overwritten by the same method in each reader
-        return key
-
-    def __setitem__(self, key, value):
-        """Regular dict-like way to store key/value pair."""
-        self.store[key] = value
-
-    def __delitem__(self, key):
-        """Regular dict-like way to delete key."""
-        del self.store[key]
-
-    def __iter__(self):
-        """Regular dict-like way to iter over object."""
-        return iter(self.store)
-
-    def __len__(self):
-        """Regular dict-like way query length of object."""
-        return len(self.store)
-
-    def keys(self):
-        """Regular dict-like way to return keys."""
-        return self.store.keys()
-
-    def values(self):
-        """Regular dict-like way to return values."""
-        return self.store.values()
-
-
 def fetch_criteria(url: str) -> dict:
     """Return parsed criteria dictionary from URL."""
     # For variable identification with cf-xarray
@@ -178,7 +46,4 @@ def fetch_criteria(url: str) -> dict:
     # https://gist.github.com/kthyng/c3cc27de6b4449e1776ce79215d5e732
     response = requests.get(url)
     response.raise_for_status()
-    data = response.json()
-    if not isinstance(data, dict):
-        raise ValueError("Remote criteria is in unknown format. {url}")
-    return data
+    return response.json()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,10 @@ def pytest_addoption(parser):
         "--runslow", action="store_true", default=False, help="run slow tests"
     )
     parser.addoption(
-        "--integration", action="store_true", default=False, help="run integration tests"
+        "--integration",
+        action="store_true",
+        default=False,
+        help="run integration tests",
     )
 
 
@@ -24,7 +27,9 @@ def pytest_collection_modifyitems(config, items):
             if "slow" in item.keywords:
                 item.add_marker(skip_slow)
     if not config.getoption("--integration"):
-        skip_integration = pytest.mark.skip(reason="need --integration to run integration tests")
+        skip_integration = pytest.mark.skip(
+            reason="need --integration to run integration tests"
+        )
         for item in items:
             if "integration" in item.keywords:
                 item.add_marker(skip_integration)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,17 +7,24 @@ def pytest_addoption(parser):
     parser.addoption(
         "--runslow", action="store_true", default=False, help="run slow tests"
     )
+    parser.addoption(
+        "--integration", action="store_true", default=False, help="run integration tests"
+    )
 
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow: mark test as slow to run")
+    config.addinivalue_line("markers", "integration: mark test as an integration test")
 
 
 def pytest_collection_modifyitems(config, items):
-    if config.getoption("--runslow"):
-        # --runslow given in cli: do not skip slow tests
-        return
-    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
-    for item in items:
-        if "slow" in item.keywords:
-            item.add_marker(skip_slow)
+    if not config.getoption("--runslow"):
+        skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+        for item in items:
+            if "slow" in item.keywords:
+                item.add_marker(skip_slow)
+    if not config.getoption("--integration"):
+        skip_integration = pytest.mark.skip(reason="need --integration to run integration tests")
+        for item in items:
+            if "integration" in item.keywords:
+                item.add_marker(skip_integration)

--- a/tests/test_erddap.py
+++ b/tests/test_erddap.py
@@ -1,3 +1,9 @@
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Generator, Optional
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -5,17 +11,67 @@ import xarray as xr
 
 import ocean_data_gateway as odg
 
+# Makes type annotations clearer
+Fixture = Generator
 
-def test_station_ioos_1dataset_id_alltime():
-    station = odg.erddap.stations({"stations": "noaa_nos_co_ops_8771013"})
+
+class MockErddap:
+    """A mock ERDDAP client."""
+    tmpdir = None
+
+    def __init__(self, server: str, protocol: Optional[str] = None, response: str = 'html'):
+        """Mock init."""
+        pass
+
+    def get_search_url(self, *args, search_for: str = 'noaa_co_ops_8771013', **kwargs) -> str:
+        fd, name = tempfile.mkstemp(dir=self.tmpdir, suffix='.csv')
+        templ = (Path(__file__).parent / 'data/search.csv').read_text()
+        data = templ.replace('DATASET_ID', search_for)
+        with os.fdopen(fd, 'r+') as f:
+            f.write(data)
+        return name
+
+    def get_info_url(self, *args, **kwargs) -> str:
+        return str(Path(__file__).parent / 'data/info.csv')
+
+    def get_download_url(self, *args, **kwargs) -> str:
+        return 'http://blahblah'
+
+    def to_xarray(self, *args, **kwargs) -> pd.DataFrame:
+        return load_testdata('co_ops_8771013.nc')
+
+
+def load_testdata(key: str) -> xr.Dataset:
+    pth = Path(__file__).parent / f'data/{key}'
+    return xr.open_dataset(pth)
+
+
+@pytest.fixture
+def mock_erddap_client() -> Fixture[MockErddap, None, None]:
+    pth_name = tempfile.mkdtemp()
+
+    class CleanupMockErddap(MockErddap):
+        tmpdir = pth_name
+
+    yield CleanupMockErddap
+    shutil.rmtree(pth_name)
+
+
+def test_station_ioos_1dataset_id_alltime(mock_erddap_client):
+    station = odg.erddap.stations({"stations": "noaa_nos_co_ops_8771013", "erddap_client_class": mock_erddap_client})
     assert station.kw == {"min_time": "1900-01-01", "max_time": "2100-12-31"}
     assert station.dataset_ids == ["noaa_nos_co_ops_8771013"]
 
 
-def test_station_ioos_1dataset_id():
+@pytest.mark.integration
+def test_station_ioos_1dataset_id_specific():
     dataset_id = "noaa_nos_co_ops_8771013"
     kw = {"min_time": "2019-1-1", "max_time": "2019-1-2"}
-    kwargs = {"stations": "noaa_nos_co_ops_8771013", "kw": kw, "parallel": False}
+    kwargs = {
+        "stations": "noaa_nos_co_ops_8771013",
+        "kw": kw,
+        "parallel": False,
+    }
     station = odg.erddap.stations(kwargs)
     assert station.kw == {"min_time": "2019-1-1", "max_time": "2019-1-2"}
     assert isinstance(station.meta, pd.DataFrame)
@@ -28,6 +84,7 @@ def test_station_ioos_1dataset_id():
     assert (data_times == known_times).all()
 
 
+@pytest.mark.integration
 def test_station_ioos_2dataset_ids():
     kw = {"min_time": "2019-1-1", "max_time": "2019-1-2"}
     dataset_ids = ["noaa_nos_co_ops_8771013", "noaa_nos_co_ops_8774230"]
@@ -36,6 +93,7 @@ def test_station_ioos_2dataset_ids():
     assert not stations.meta.empty
 
 
+@pytest.mark.integration
 def test_station_ioos_1station():
     kw = {"min_time": "2019-1-1", "max_time": "2019-1-2"}
     stationname = "8771013"
@@ -44,6 +102,7 @@ def test_station_ioos_1station():
     assert not stations.meta.empty
 
 
+@pytest.mark.integration
 def test_station_ioos_2stations():
     kw = {"min_time": "2019-1-1", "max_time": "2019-1-2"}
     dataset_ids = ["noaa_nos_co_ops_8771013", "noaa_nos_co_ops_8774230"]

--- a/tests/test_erddap.py
+++ b/tests/test_erddap.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import tempfile
+
 from pathlib import Path
 from typing import Generator, Optional
 
@@ -11,38 +12,44 @@ import xarray as xr
 
 import ocean_data_gateway as odg
 
+
 # Makes type annotations clearer
 Fixture = Generator
 
 
 class MockErddap:
     """A mock ERDDAP client."""
+
     tmpdir = None
 
-    def __init__(self, server: str, protocol: Optional[str] = None, response: str = 'html'):
+    def __init__(
+        self, server: str, protocol: Optional[str] = None, response: str = "html"
+    ):
         """Mock init."""
         pass
 
-    def get_search_url(self, *args, search_for: str = 'noaa_co_ops_8771013', **kwargs) -> str:
-        fd, name = tempfile.mkstemp(dir=self.tmpdir, suffix='.csv')
-        templ = (Path(__file__).parent / 'data/search.csv').read_text()
-        data = templ.replace('DATASET_ID', search_for)
-        with os.fdopen(fd, 'r+') as f:
+    def get_search_url(
+        self, *args, search_for: str = "noaa_co_ops_8771013", **kwargs
+    ) -> str:
+        fd, name = tempfile.mkstemp(dir=self.tmpdir, suffix=".csv")
+        templ = (Path(__file__).parent / "data/search.csv").read_text()
+        data = templ.replace("DATASET_ID", search_for)
+        with os.fdopen(fd, "r+") as f:
             f.write(data)
         return name
 
     def get_info_url(self, *args, **kwargs) -> str:
-        return str(Path(__file__).parent / 'data/info.csv')
+        return str(Path(__file__).parent / "data/info.csv")
 
     def get_download_url(self, *args, **kwargs) -> str:
-        return 'http://blahblah'
+        return "http://blahblah"
 
     def to_xarray(self, *args, **kwargs) -> pd.DataFrame:
-        return load_testdata('co_ops_8771013.nc')
+        return load_testdata("co_ops_8771013.nc")
 
 
 def load_testdata(key: str) -> xr.Dataset:
-    pth = Path(__file__).parent / f'data/{key}'
+    pth = Path(__file__).parent / f"data/{key}"
     return xr.open_dataset(pth)
 
 
@@ -58,7 +65,12 @@ def mock_erddap_client() -> Fixture[MockErddap, None, None]:
 
 
 def test_station_ioos_1dataset_id_alltime(mock_erddap_client):
-    station = odg.erddap.stations({"stations": "noaa_nos_co_ops_8771013", "erddap_client_class": mock_erddap_client})
+    station = odg.erddap.stations(
+        {
+            "stations": "noaa_nos_co_ops_8771013",
+            "erddap_client_class": mock_erddap_client,
+        }
+    )
     assert station.kw == {"min_time": "1900-01-01", "max_time": "2100-12-31"}
     assert station.dataset_ids == ["noaa_nos_co_ops_8771013"]
 

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -1,15 +1,24 @@
-import numpy as np  # noqa: E402
-import pandas as pd  # noqa: E402
+#!/usr/bin/env pytest
+# -*- coding: utf-8 -*-
+"""Unit tests for odg.Gateway."""
+import numpy as np
+import pandas as pd
+import pint_xarray
 import pytest
-import xarray as xr  # noqa: E402
-
+import xarray as xr
 from make_test_files import make_local_netcdf
 
 import ocean_data_gateway as odg
-
+from ocean_data_gateway import readers
+from ocean_data_gateway.gateway import Gateway
+from ocean_data_gateway.readers import DataReader, ErddapReader
+from ocean_data_gateway.readers.axds import stations as axds_stations
+from ocean_data_gateway.readers.erddap import region as erddap_region
+from ocean_data_gateway.readers.erddap import stations as erddap_stations
+from ocean_data_gateway.readers.local import stations as local_stations
 
 from cf_xarray.units import units  # isort:skip
-import pint_xarray  # isort:skip
+
 
 pint_xarray.unit_registry = units  # isort:skip
 
@@ -74,3 +83,64 @@ def test_qc_error():
 
     with pytest.raises(AssertionError):
         assert (data.qc()[fname]["temperature_qc"] == np.ones(10)).all()
+
+
+def test_default_readers():
+    readers = Gateway._get_module_readers()
+    assert DataReader in readers
+    assert ErddapReader in readers
+
+
+def test_default_sources():
+    gateway = odg.Gateway(
+        approach="stations",
+    )
+    for source in gateway.sources:
+        assert any(
+            [isinstance(source, i)]
+            for i in [axds_stations, erddap_stations, local_stations]
+        )
+
+
+def test_ioos_erddap_source():
+    gateway = odg.Gateway(
+        **{
+            "approach": "stations",
+            "erddap": {
+                "known_server": "ioos",
+                "variables": "salinity",
+            },
+            "readers": readers.erddap,
+        }
+    )
+    assert len(gateway.sources) == 1
+    assert all([isinstance(i, erddap_stations) for i in gateway.sources])
+    assert gateway.sources[0].parallel is True
+    assert gateway.sources[0].known_server == "ioos"
+    assert gateway.sources[0].filetype == "netcdf"
+    assert gateway.sources[0].kw == {"min_time": "1900-01-01", "max_time": "2100-12-31"}
+
+
+def test_gateway_by_region():
+    gateway = odg.Gateway(
+        **{
+            "kw": {
+                "min_lon": -124.0,
+                "max_lon": -123.0,
+                "min_lat": 39.0,
+                "max_lat": 40.0,
+                "min_time": "2021-4-1",
+                "max_time": "2021-4-2",
+            },
+            "approach": "region",
+            "erddap": {
+                "known_server": "ioos",
+                "variables": "salinity",
+            },
+            "readers": readers.erddap,
+        }
+    )
+    assert len(gateway.sources) == 1
+    assert all([isinstance(i, erddap_region) for i in gateway.sources])
+    assert gateway.sources[0].parallel is True
+    assert gateway.sources[0].variables == ["salinity"]

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -85,11 +85,6 @@ def test_qc_error():
         assert (data.qc()[fname]["temperature_qc"] == np.ones(10)).all()
 
 
-def test_default_readers():
-    readers = Gateway._get_module_readers()
-    assert DataReader in readers
-    assert ErddapReader in readers
-
 
 def test_default_sources():
     gateway = odg.Gateway(

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -6,9 +6,11 @@ import pandas as pd
 import pint_xarray
 import pytest
 import xarray as xr
+
 from make_test_files import make_local_netcdf
 
 import ocean_data_gateway as odg
+
 from ocean_data_gateway import readers
 from ocean_data_gateway.gateway import Gateway
 from ocean_data_gateway.readers import DataReader, ErddapReader
@@ -16,6 +18,7 @@ from ocean_data_gateway.readers.axds import stations as axds_stations
 from ocean_data_gateway.readers.erddap import region as erddap_region
 from ocean_data_gateway.readers.erddap import stations as erddap_stations
 from ocean_data_gateway.readers.local import stations as local_stations
+
 
 from cf_xarray.units import units  # isort:skip
 
@@ -83,7 +86,6 @@ def test_qc_error():
 
     with pytest.raises(AssertionError):
         assert (data.qc()[fname]["temperature_qc"] == np.ones(10)).all()
-
 
 
 def test_default_sources():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 import pandas as pd
 import pytest
+from requests import HTTPError
 import xarray as xr
 
 import ocean_data_gateway as odg
@@ -39,6 +40,7 @@ def test_fetch_criteria_expects_dict(requests_mock):
     utils.fetch_criteria(url)
     assert resp.raise_for_status.called
 
+    resp.raise_for_status.side_effect = HTTPError('test')
     resp.json.return_value = []
-    with pytest.raises(ValueError):
+    with pytest.raises(HTTPError):
         utils.fetch_criteria(url)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,8 +5,9 @@ from unittest import mock
 
 import pandas as pd
 import pytest
-from requests import HTTPError
 import xarray as xr
+
+from requests import HTTPError
 
 import ocean_data_gateway as odg
 
@@ -40,7 +41,7 @@ def test_fetch_criteria_expects_dict(requests_mock):
     utils.fetch_criteria(url)
     assert resp.raise_for_status.called
 
-    resp.raise_for_status.side_effect = HTTPError('test')
+    resp.raise_for_status.side_effect = HTTPError("test")
     resp.json.return_value = []
     with pytest.raises(HTTPError):
         utils.fetch_criteria(url)


### PR DESCRIPTION
This PR contains restructuring to improve maintainability and readability. This narrowly affects the API only where security is an issue and subsequent pull-requests _will_ modify the API as appropriate.

- Fixes ioos_qc compatibility issues
- Moves some global variables to class variables: this narrows the scope of the variable and makes its purpose and context more clear as relating to a gateway and how it initializes the reader
- Adds an intermediate DataReader class which implements the previously defined functions which were dynamically called (while unbound) from class instances. This modifies the invocation approach from half-complete polymorphism to class inheritance (polymorphism).
- Breaks up the `sources` property in the Gateway class so that it's readable and maintainable. The refactor reduces the cognitive complexity of the method significantly and removes dead code that used to be evaluated but ultimately unused.
- Adds unit tests verifying the API and expectations for the gateway class
- Adds pytest mark for ingegration which will eventually be used to mark all tests that rely on external services.